### PR TITLE
enable output of association/link names

### DIFF
--- a/Generate.hs
+++ b/Generate.hs
@@ -18,7 +18,7 @@ generate c searchSpace = do
     then do
       let names = classNames ncls
       es <- generateEdges names nins ncos nass nags
-      return (names, es)
+      return (names, nameEdges es)
     else if smallerC == c
          then error "it seems to be impossible to generate such a model; check your configuration"
          else generate smallerC searchSpace
@@ -43,6 +43,12 @@ generate c searchSpace = do
       | inh >= cla                                      = False
       | cla * (cla - 1) `div` 2 < inh + com + ass + agg = False
       | otherwise                                       = True
+
+nameEdges :: [DiagramEdge] -> [DiagramEdge]
+nameEdges es =
+     [e | e@(_, _, Inheritance) <- es]
+  ++ [(s, e, Assoc k (n:[]) m1 m2 b)
+     | (n, (s, e, Assoc k _ m1 m2 b)) <- zip ['z', 'y' ..] es]
 
 generateEdges :: [String] -> Int -> Int -> Int -> Int -> IO [DiagramEdge]
 generateEdges classs inh com ass agg =
@@ -70,11 +76,11 @@ generateEdges classs inh com ass agg =
     generateLimits (Just Composition) = do
       ll1 <- randomRIO (0, 1)
       l2  <- generateLimit
-      return $ Assoc Composition (ll1, Just 1) l2 False
+      return $ Assoc Composition "" (ll1, Just 1) l2 False
     generateLimits (Just t          ) = do
       l1 <- generateLimit
       l2 <- generateLimit
-      return $ Assoc t l1 l2 False
+      return $ Assoc t "" l1 l2 False
     generateLimit :: IO (Int, Maybe Int)
     generateLimit = do
       l <- randomRIO (0, 2)

--- a/Output.hs
+++ b/Output.hs
@@ -64,7 +64,7 @@ drawOdFromInstance :: Bool -> String -> FilePath -> GraphvizOutput -> IO ()
 drawOdFromInstance printNames input file format = do
   let [objLine, objGetLine] = filter ("this/Obj" `isPrefixOf`) (lines input)
   let theNodes = splitOn ", " (init (tail (fromJust (stripPrefix "this/Obj=" objLine))))
-  let theEdges = map ((\[from,v,to] -> (fromJust (elemIndex from theNodes), fromJust (elemIndex to theNodes), v)) . splitOn "->") $
+  let theEdges = map ((\[from,v:"$0",to] -> (fromJust (elemIndex from theNodes), fromJust (elemIndex to theNodes), v:[])) . splitOn "->") $
                  filter (not . null) (splitOn ", " (init (tail (fromJust (stripPrefix "this/Obj<:get=" objGetLine)))))
   let graph = undir (mkGraph (zip [0..] theNodes) theEdges) :: Gr String String
   let dotGraph = setDirectedness graphToDot (nonClusteredParams { fmtNode = \(_,l) -> [underlinedLabel (firstLower l ++ " : " ++ takeWhile (/= '$') l), shape BoxShape], fmtEdge = \(_,_,l) -> [label l | printNames] }) graph

--- a/Output.hs
+++ b/Output.hs
@@ -13,13 +13,19 @@ import Data.GraphViz.Attributes.Complete
 
 import System.FilePath (dropExtension)
 
-connectionArrow :: Connection -> [Attribute]
-connectionArrow Inheritance = [arrowTo emptyArr]
-connectionArrow (Assoc Composition from to isRed) =
-  case from of
-    (1, Just 1) -> arrow Composition ++ [HeadLabel (mult to)] ++ [redColor | isRed]
-    (0, Just 1) -> arrow Composition ++ [TailLabel (mult from), HeadLabel (mult to)] ++ [redColor | isRed]
-connectionArrow (Assoc a from to isRed) = arrow a ++ [TailLabel (mult from), HeadLabel (mult to)] ++ [redColor | isRed]
+connectionArrow :: Bool -> Connection -> [Attribute]
+connectionArrow _          Inheritance =
+  [arrowTo emptyArr]
+connectionArrow printNames (Assoc Composition name from to isRed) =
+  arrow Composition ++ [HeadLabel (mult to), LabelScheme CloseToOldCenter]
+  ++ [redColor | isRed] ++ [label name | printNames]
+  ++ case from of
+       (1, Just 1) -> []
+       (0, Just 1) -> [TailLabel (mult from)]
+       _           -> error $ "invalid composition multiplicity"
+connectionArrow printNames (Assoc a name from to isRed) =
+  arrow a ++ [TailLabel (mult from), HeadLabel (mult to), LabelScheme CloseToOldCenter]
+  ++ [redColor | isRed] ++ [label name | printNames]
 
 arrow :: AssociationType -> [Attribute]
 arrow Association = [ArrowHead noArrow]
@@ -32,8 +38,11 @@ mult (l, Nothing) = toLabelValue (show l ++ "..*")
 mult (l, Just u) | l == u    = toLabelValue l
                  | otherwise = toLabelValue (show l ++ ".." ++ show u)
 
-drawCdFromSyntax :: Syntax -> FilePath -> GraphvizOutput -> IO ()
-drawCdFromSyntax syntax file format = do
+label :: String -> Attribute
+label = Label . toLabelValue
+
+drawCdFromSyntax :: Bool -> Syntax -> FilePath -> GraphvizOutput -> IO ()
+drawCdFromSyntax printNames syntax file format = do
   let (classes, associations) = syntax
   let classNames = map fst classes
   let theNodes = classNames
@@ -44,9 +53,9 @@ drawCdFromSyntax syntax file format = do
             | name `elem` seen = []
             | otherwise = name : concatMap (subs (name:seen) . fst) (filter ((== Just name) . snd) classes)
   let assocsBothWays = concatMap (\(_,_,_,from,to,_) -> [(from,to), (to,from)]) associations
-  let assocEdges = map (\(a,_,m1,from,to,m2) -> (fromJust (elemIndex from theNodes), fromJust (elemIndex to theNodes), Assoc a m1 m2 (shouldBeRed from to classesWithSubclasses assocsBothWays))) associations
+  let assocEdges = map (\(a,n,m1,from,to,m2) -> (fromJust (elemIndex from theNodes), fromJust (elemIndex to theNodes), Assoc a n m1 m2 (shouldBeRed from to classesWithSubclasses assocsBothWays))) associations
   let graph = mkGraph (zip [0..] theNodes) (inhEdges ++ assocEdges) :: Gr String Connection
-  let dotGraph = graphToDot (nonClusteredParams { fmtNode = \(_,l) -> [toLabel l, shape BoxShape], fmtEdge = \(_,_,l) -> connectionArrow l }) graph
+  let dotGraph = graphToDot (nonClusteredParams { fmtNode = \(_,l) -> [toLabel l, shape BoxShape], fmtEdge = \(_,_,l) -> connectionArrow printNames l }) graph
   quitWithoutGraphviz "Please install GraphViz executables from http://graphviz.org/ and put them on your PATH"
   output <- addExtension (runGraphviz dotGraph) format (dropExtension file)
   putStrLn $ "Output written to " ++ output

--- a/Output.hs
+++ b/Output.hs
@@ -17,14 +17,14 @@ connectionArrow :: Bool -> Connection -> [Attribute]
 connectionArrow _          Inheritance =
   [arrowTo emptyArr]
 connectionArrow printNames (Assoc Composition name from to isRed) =
-  arrow Composition ++ [HeadLabel (mult to), LabelScheme CloseToOldCenter]
+  arrow Composition ++ [HeadLabel (mult to)]
   ++ [redColor | isRed] ++ [label name | printNames]
   ++ case from of
        (1, Just 1) -> []
        (0, Just 1) -> [TailLabel (mult from)]
        _           -> error $ "invalid composition multiplicity"
 connectionArrow printNames (Assoc a name from to isRed) =
-  arrow a ++ [TailLabel (mult from), HeadLabel (mult to), LabelScheme CloseToOldCenter]
+  arrow a ++ [TailLabel (mult from), HeadLabel (mult to)]
   ++ [redColor | isRed] ++ [label name | printNames]
 
 arrow :: AssociationType -> [Attribute]
@@ -60,14 +60,14 @@ drawCdFromSyntax printNames syntax file format = do
   output <- addExtension (runGraphviz dotGraph) format (dropExtension file)
   putStrLn $ "Output written to " ++ output
 
-drawOdFromInstance :: String -> FilePath -> GraphvizOutput -> IO ()
-drawOdFromInstance input file format = do
+drawOdFromInstance :: Bool -> String -> FilePath -> GraphvizOutput -> IO ()
+drawOdFromInstance printNames input file format = do
   let [objLine, objGetLine] = filter ("this/Obj" `isPrefixOf`) (lines input)
   let theNodes = splitOn ", " (init (tail (fromJust (stripPrefix "this/Obj=" objLine))))
-  let theEdges = map ((\[from,_,to] -> (fromJust (elemIndex from theNodes), fromJust (elemIndex to theNodes), ())) . splitOn "->") $
+  let theEdges = map ((\[from,v,to] -> (fromJust (elemIndex from theNodes), fromJust (elemIndex to theNodes), v)) . splitOn "->") $
                  filter (not . null) (splitOn ", " (init (tail (fromJust (stripPrefix "this/Obj<:get=" objGetLine)))))
-  let graph = undir (mkGraph (zip [0..] theNodes) theEdges) :: Gr String ()
-  let dotGraph = setDirectedness graphToDot (nonClusteredParams { fmtNode = \(_,l) -> [underlinedLabel (firstLower l ++ " : " ++ takeWhile (/= '$') l), shape BoxShape] }) graph
+  let graph = undir (mkGraph (zip [0..] theNodes) theEdges) :: Gr String String
+  let dotGraph = setDirectedness graphToDot (nonClusteredParams { fmtNode = \(_,l) -> [underlinedLabel (firstLower l ++ " : " ++ takeWhile (/= '$') l), shape BoxShape], fmtEdge = \(_,_,l) -> [label l | printNames] }) graph
   quitWithoutGraphviz "Please install GraphViz executables from http://graphviz.org/ and put them on your PATH"
   output <- addExtension (runGraphviz dotGraph) format (dropExtension file)
   putStrLn $ "Output written to " ++ output

--- a/Types.hs
+++ b/Types.hs
@@ -5,7 +5,7 @@ type Association = (AssociationType, String, (Int, Maybe Int), String, String, (
 data AssociationType = Association | Aggregation | Composition
   deriving Eq
 
-data Connection = Inheritance | Assoc AssociationType (Int, Maybe Int) (Int, Maybe Int) Bool
+data Connection = Inheritance | Assoc AssociationType String (Int, Maybe Int) (Int, Maybe Int) Bool
   deriving Eq
 
 type Syntax = ([(String, Maybe String)], [Association])

--- a/cd2pic.hs
+++ b/cd2pic.hs
@@ -13,7 +13,7 @@ run :: String -> FilePath -> GraphvizOutput -> IO ()
 run input = do
   let tokens = lexer input
   let syntax = parser tokens
-  drawCdFromSyntax True syntax
+  drawCdFromSyntax False syntax
 
 main :: IO ()
 main = do

--- a/cd2pic.hs
+++ b/cd2pic.hs
@@ -13,7 +13,7 @@ run :: String -> FilePath -> GraphvizOutput -> IO ()
 run input = do
   let tokens = lexer input
   let syntax = parser tokens
-  drawCdFromSyntax syntax
+  drawCdFromSyntax True syntax
 
 main :: IO ()
 main = do

--- a/instance2pic.hs
+++ b/instance2pic.hs
@@ -11,7 +11,7 @@ main :: IO ()
 main = do
   args <- getArgs
   case args of
-   [] -> getContents >>= \contents -> drawOdFromInstance contents "output" Pdf
-   [file] -> readFile file >>= \contents -> drawOdFromInstance contents file Pdf
-   [file, format] -> readFile file >>= \contents -> drawOdFromInstance contents file (read (firstUpper format))
+   [] -> getContents >>= \contents -> drawOdFromInstance False contents "output" Pdf
+   [file] -> readFile file >>= \contents -> drawOdFromInstance False contents file Pdf
+   [file, format] -> readFile file >>= \contents -> drawOdFromInstance False contents file (read (firstUpper format))
    _ -> error "zu viele Parameter"

--- a/random-stuff.hs
+++ b/random-stuff.hs
@@ -45,7 +45,7 @@ main = do
       nonEmpty2 <- Alloy.existInstances als2
       when nonEmpty2 $ do
         instances12 <- Alloy.getInstances maxInstances als12
-        mapM_ (\(i, insta) -> drawOdFromInstance insta (show i) Pdf) (zip [1 :: Integer ..] instances12)
+        mapM_ (\(i, insta) -> drawOdFromInstance True insta (show i) Pdf) (zip [1 :: Integer ..] instances12)
   where
     unionL x y = unlines $ lines x `union` lines y
 

--- a/random-stuff.hs
+++ b/random-stuff.hs
@@ -29,7 +29,7 @@ main = do
   let output = "output"
   let maxInstances = -1
   let cd1 = fromEdges names edges
-  drawCdFromSyntax cd1 (output ++ "1") Pdf
+  drawCdFromSyntax True cd1 (output ++ "1") Pdf
   unless (anyRedEdge cd1) $ do
     let (part1, part2, part3, part4, part5) = transform cd1 "1" ""
         als1 = part1 ++ part2 ++ part3 ++ part4 ++ part5
@@ -41,7 +41,7 @@ main = do
           als2  = part1' ++ part2' ++ part3' ++ part4' ++ part5'
           als12 = part1 ++ (part2 `unionL` part2') ++ (part3 `unionL` part3')
                   ++ part4 ++ part4' ++ "run { cd1 and (not cd2) } for 5"
-      drawCdFromSyntax cd2 (output ++ "2") Pdf
+      drawCdFromSyntax True cd2 (output ++ "2") Pdf
       nonEmpty2 <- Alloy.existInstances als2
       when nonEmpty2 $ do
         instances12 <- Alloy.getInstances maxInstances als12


### PR DESCRIPTION
The reason being that without those names, things can be ambiguous, and results misleading, after all.

Consider `cd1`:
![issue1](https://user-images.githubusercontent.com/5853832/52999956-743c7980-3427-11e9-9c69-427e15e07d18.png)
and `cd2`:
![issue2](https://user-images.githubusercontent.com/5853832/52999977-7f8fa500-3427-11e9-8969-2ba70ddc2861.png)
Then running `{ cd1 and (not cd2) }` produces this instance:
![issue](https://user-images.githubusercontent.com/5853832/52999999-8c13fd80-3427-11e9-87e1-c3c4686e74a0.png)
But it is only true that the latter is not an instance for `cd2` *if* we know that the link is supposed to be of an association between `A` and `B` directly, as in `cd1`.

Writing the association names into the class and object diagrams would clear this up.