### PR TITLE
Set scope for FName

### DIFF
--- a/Alloy.hs
+++ b/Alloy.hs
@@ -1,20 +1,21 @@
 module Alloy where
 
+import Control.Monad   (when)
 import Data.List       (intercalate)
 import Data.List.Split (splitOn)
-
+import System.Exit     (ExitCode (..))
 import System.FilePath (searchPathSeparator)
-import System.IO
+import System.IO       (hClose, hGetLine, hIsEOF, hPutStr)
 import System.Process
 
 getInstances :: Int -> String -> IO [String]
 getInstances maxInstances content = do
   let callAlloy = proc "java" ["-cp", '.' : searchPathSeparator : "alloy/Alloy-5.0.0.1.jar",
                                "alloy.RunAlloy", show maxInstances]
-  (Just hin, Just hout, _, _) <- createProcess callAlloy { std_out = CreatePipe, std_in = CreatePipe }
+  (Just hin, Just hout, _, ph) <- createProcess callAlloy { std_out = CreatePipe, std_in = CreatePipe }
   hPutStr hin content
   hClose hin
-  fmap (intercalate "\n") . drop 1 . splitOn [begin] <$> getWholeOutput hout
+  printContentOnError ph `seq` fmap (intercalate "\n") . drop 1 . splitOn [begin] <$> getWholeOutput hout
   where
     begin = "---INSTANCE---"
     getWholeOutput h = do
@@ -22,6 +23,9 @@ getInstances maxInstances content = do
       if eof
         then return []
         else (:) <$> hGetLine h <*> getWholeOutput h
+    printContentOnError ph = do
+      code <- waitForProcess ph
+      when (code /= ExitSuccess) $ putStrLn content
 
 existInstances :: String -> IO Bool
 existInstances = fmap (not . null) . getInstances 1

--- a/Mutation.hs
+++ b/Mutation.hs
@@ -2,7 +2,9 @@ module Mutation (
   -- * Types
   Mutation (..), Targets, Target (..), Alteration (..),
   -- * Perform mutation operations
-  getAllMutationResults, getMutationResults
+  getAllMutationResults, getMutationResults,
+  -- * Utility functions
+  nonTargets
   ) where
 
 import Types
@@ -90,6 +92,10 @@ isTargetsEdge x ts = any (x `isTargetEdge`) ts
 targets :: Targets -> [DiagramEdge] -> [DiagramEdge]
 targets ts es =
   [e | e <- es, isTargetsEdge e ts]
+
+nonTargets :: Targets -> [DiagramEdge] -> [DiagramEdge]
+nonTargets ts es =
+  [e | e <- es, not $ isTargetsEdge e ts]
 
 targetEdgesCount :: Target -> [DiagramEdge] -> Int
 targetEdgesCount t es = length [e | e <- es, isTargetEdge e t]

--- a/random-task.hs
+++ b/random-task.hs
@@ -2,7 +2,7 @@ module Main (main) where
 
 import Edges
 import Generate  (generate)
-import Mutation  (getAllMutationResults)
+import Mutation  (Target (..), getAllMutationResults, nonTargets)
 import Output    (drawCdFromSyntax, drawOdFromInstance)
 import Transform (createRunCommand, transform)
 import Types     (ClassConfig (..))
@@ -12,6 +12,7 @@ import qualified Alloy (getInstances)
 import Data.List             (union)
 import Data.GraphViz         (GraphvizOutput (Pdf))
 import Data.Maybe            (isJust)
+import Data.Set              (singleton)
 import System.Random.Shuffle (shuffleM)
 
 main :: IO ()
@@ -41,24 +42,25 @@ getRandomTask config output searchSpace maxInstances = do
         cd2not3 = createRunCommand "cd2 and (not cd3)" (length names) 5
         cd3not2 = createRunCommand "cd3 and (not cd2)" (length names) 5
         cd2and3 = createRunCommand "cd2 and cd3" (length names) 5
-    instances2not3 <- getInstancesOfMerged parts2 parts3 cd2not3
-    instances3not2 <- getInstancesOfMerged parts2 parts3 cd3not2
-    instances2and3 <- getInstancesOfMerged parts2 parts3 cd2and3
-    let takes = [ (take x, take y, take z)
-                | x <- [0 .. min 3 (length instances2not3)]
-                , y <- [0 .. min 3 (length instances3not2)]
-                , z <- [0 .. min 3 (length instances2and3)]
-                , 5 == x + y + z ]
-    continueIf (not $ null takes) $ do
-      (take2not3, take3not2, take2and3) <- head <$> shuffleM takes
-      shuffled2not3 <- take2not3 <$> shuffleM instances2not3
-      shuffled3not2 <- take3not2 <$> shuffleM instances3not2
-      shuffled2and3 <- take2and3 <$> shuffleM instances2and3
-      drawCdFromSyntax True cd2 (output ++ '-' : "2") Pdf
-      drawCdFromSyntax True cd3 (output ++ '-' : "3") Pdf
-      mapM_ (uncurry $ drawOd "2not3") $ zip [1 :: Integer ..] shuffled2not3
-      mapM_ (uncurry $ drawOd "3not2") $ zip [1 :: Integer ..] shuffled3not2
-      mapM_ (uncurry $ drawOd "2and3") $ zip [1 :: Integer ..] shuffled2and3
+    continueIf (not $ null $ nonTargets (singleton TInheritance) $ edges2 ++ edges3) $ do
+      instances2not3 <- getInstancesOfMerged parts2 parts3 cd2not3
+      instances3not2 <- getInstancesOfMerged parts2 parts3 cd3not2
+      instances2and3 <- getInstancesOfMerged parts2 parts3 cd2and3
+      let takes = [ (take x, take y, take z)
+                  | x <- [0 .. min 3 (length instances2not3)]
+                  , y <- [0 .. min 3 (length instances3not2)]
+                  , z <- [0 .. min 3 (length instances2and3)]
+                  , 5 == x + y + z ]
+      continueIf (not $ null takes) $ do
+        (take2not3, take3not2, take2and3) <- head <$> shuffleM takes
+        shuffled2not3 <- take2not3 <$> shuffleM instances2not3
+        shuffled3not2 <- take3not2 <$> shuffleM instances3not2
+        shuffled2and3 <- take2and3 <$> shuffleM instances2and3
+        drawCdFromSyntax True cd2 (output ++ '-' : "2") Pdf
+        drawCdFromSyntax True cd3 (output ++ '-' : "3") Pdf
+        mapM_ (uncurry $ drawOd "2not3") $ zip [1 :: Integer ..] shuffled2not3
+        mapM_ (uncurry $ drawOd "3not2") $ zip [1 :: Integer ..] shuffled3not2
+        mapM_ (uncurry $ drawOd "2and3") $ zip [1 :: Integer ..] shuffled2and3
   where
     continueIf True  m = m
     continueIf False _ = getRandomTask config output searchSpace maxInstances


### PR DESCRIPTION
Occasionally, Alloy fails with an error message, that an scope for FName is missing.
```Java
You must specify a scope for sig "this/FName"
	at edu.mit.csail.sdg.translator.ScopeComputer.derive_overall_scope(ScopeComputer.java:256)
	at edu.mit.csail.sdg.translator.ScopeComputer.<init>(ScopeComputer.java:401)
	at edu.mit.csail.sdg.translator.ScopeComputer.compute(ScopeComputer.java:469)
	at edu.mit.csail.sdg.translator.TranslateAlloyToKodkod.<init>(TranslateAlloyToKodkod.java:148)
	at edu.mit.csail.sdg.translator.TranslateAlloyToKodkod.execute_command(TranslateAlloyToKodkod.java:535)
	at alloy.RunAlloy.main(RunAlloy.java:39)
```