### PR TITLE
CI tweaking

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ on:
       - master
 
 jobs:
-  build:
+  consistency:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,7 +11,7 @@ on:
       - master
 
 jobs:
-  build:
+  build_and_test:
     strategy:
       matrix:
 #        os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -126,7 +126,7 @@ jobs:
         BUILD: ${{ matrix.plan.build }}
       if: contains(matrix.os, 'windows')
 
-    - name: Build on unix
+    - name: Build and test on unix
       run: |
         set -ex
         case "$BUILD" in
@@ -160,7 +160,7 @@ jobs:
         CABALVER: ${{ matrix.plan.cabal-install }}
       if: contains(matrix.os, 'windows') == false
 
-    - name: Build on windows
+    - name: Build and test on windows
       shell: powershell
       run: |
         switch ( "${env:BUILD}" ) {

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,14 +17,10 @@ jobs:
 #        os: [ubuntu-latest, macOS-latest, windows-latest]
         os: [ubuntu-latest]
         plan:
-          - { build: stack }
-#          - { build: cabal, ghc: "8.8.3", cabal-install: "latest" }
+          - { resolver: "" }
         include:
           - os: ubuntu-latest
             apt-get: graphviz texlive-base texlive-latex-base
-        exclude:
-          - os: windows-latest
-            plan: { cabal-install: "latest" }
 
     runs-on: ${{ matrix.os }}
 
@@ -41,7 +37,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.stack
-        key: ${{ matrix.os }}-${{ matrix.plan.build }}-stack-home-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+        key: ${{ matrix.os }}-${{ matrix.plan.resolver }}-stack-home-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       if: contains(matrix.os, 'windows') == false
 
     - name: Cache Stack on windows
@@ -49,24 +45,8 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/AppData/Local/Programs/stack
-        key: ${{ matrix.os }}-${{ matrix.plan.build }}-stack-home-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+        key: ${{ matrix.os }}-${{ matrix.plan.resolver }}-stack-home-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       if: contains(matrix.os, 'windows')
-
-    - name: Cache Cabal on unix
-      id: cache-cabal-unix
-      uses: actions/cache@v1
-      with:
-        path: ~/.cabal
-        key: ${{ matrix.os }}-${{ matrix.plan.build }}-${{ matrix.plan.ghc }}-${{ matrix.plan.cabal-install }}-cabal-home-${{ hashFiles('**/*.cabal')}}-${{ hashFiles('package.yaml') }}
-      if: matrix.plan.build == 'cabal' && contains(matrix.os, 'windows') == false
-
-    - name: Cache Cabal on windows
-      id: cache-cabal-windows
-      uses: actions/cache@v1
-      with:
-        path: ~/AppData/Roaming/cabal
-        key: ${{ matrix.os }}-${{ matrix.plan.build }}-${{ matrix.plan.ghc }}-${{ matrix.plan.cabal-install }}-cabal-home-${{ hashFiles('**/*.cabal')}}-${{ hashFiles('package.yaml') }}
-      if: matrix.plan.build == 'cabal' && contains(matrix.os, 'windows')
 
     - name: Setup stack
       uses: haskell/actions/setup@v1
@@ -74,128 +54,36 @@ jobs:
         enable-stack: true
         stack-no-global: true
 
-    - name: Setup ghc ${{ matrix.plan.ghc }} and cabal-install ${{ matrix.plan.cabal-install }}
-      uses: actions/setup-haskell@81544724478d8ba4d4e38eddea0351a215d25291
-      with:
-        ghc-version: ${{ matrix.plan.ghc }}
-        cabal-version: ${{ matrix.plan.cabal-install }}
-      if: matrix.plan.build == 'cabal'
-
     - name: Install dependencies on unix
       run: |
         set -ex
-        case "$BUILD" in
-          stack)
-            stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
-            ;;
-          cabal)
-            cabal --version
-            cabal update
-            PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
-            cabal install --overwrite-policy=always --only-dependencies --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
-            ;;
-        esac
+        stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
         set +ex
       env:
         ARGS: ${{ matrix.plan.resolver }}
-        BUILD: ${{ matrix.plan.build }}
       if: contains(matrix.os, 'windows') == false
 
     - name: Install dependencies on windows
       shell: powershell
       run: |
-        switch ( "${env:BUILD}" ) {
-          "stack" {
-            stack --no-terminal --install-ghc ${env:ARGS} test --bench --only-dependencies
-          }
-          "cabal" {
-            cabal --version
-            cabal update
-            $PACKAGES=Invoke-Expression @'
-              stack --no-terminal --install-ghc query locals | Select-String -Pattern '^ *path' | %{ $_ -replace '^ *path:', '' }
-        '@
-            cabal install --overwrite-policy=always --only-dependencies --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 ${env:CABALARGS} $PACKAGES
-          }
-          default {
-            echo "invalid type $BUILD"
-            exit 1
-          }
-        }
+        stack --no-terminal --install-ghc ${env:ARGS} test --bench --only-dependencies
       env:
         ARGS: ${{ matrix.plan.resolver }}
-        BUILD: ${{ matrix.plan.build }}
       if: contains(matrix.os, 'windows')
 
     - name: Build and test on unix
       run: |
         set -ex
-        case "$BUILD" in
-          stack)
-            stack --no-terminal $ARGS test --stack-yaml=stack-apps.yaml --bench --no-run-benchmarks --haddock --no-haddock-deps --test-arguments="--maximum-generated-tests=50"
-            ;;
-          cabal)
-            PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
-            cabal install --overwrite-policy=always --ghc-options="-O0 -Wall -Werror" --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
-            ORIGDIR=$(pwd)
-            for dir in $PACKAGES
-            do
-              cd $dir
-              # cabal check || [ "$CABALVER" == "1.16" ]
-              # cabal sdist
-              # PKGVER=$(cabal info . | awk '{print $2;exit}')
-              # SRC_TGZ=$PKGVER.tar.gz
-              # cd dist
-              # tar zxfv "$SRC_TGZ"
-              # cd "$PKGVER"
-              cabal configure --ghc-options -O0
-              cabal build
-              cd $ORIGDIR
-            done
-            ;;
-        esac
+        stack --no-terminal $ARGS test --stack-yaml=stack-apps.yaml --bench --no-run-benchmarks --haddock --no-haddock-deps --test-arguments="--maximum-generated-tests=50"
         set +ex
       env:
         ARGS: ${{ matrix.plan.resolver }}
-        BUILD: ${{ matrix.plan.build }}
-        CABALVER: ${{ matrix.plan.cabal-install }}
       if: contains(matrix.os, 'windows') == false
 
     - name: Build and test on windows
       shell: powershell
       run: |
-        switch ( "${env:BUILD}" ) {
-          "stack" {
-            stack --no-terminal --install-ghc ${env:ARGS} test --stack-yaml=stack-apps.yaml --bench --only-dependencies --test-arguments="--maximum-generated-tests=50"
-          }
-          "cabal" {
-            $PACKAGES=Invoke-Expression @'
-              stack --no-terminal --install-ghc query locals | Select-String -Pattern '^ *path' | %{ $_ -replace '^ *path:', '' }
-        '@
-            cabal install --overwrite-policy=always --force-reinstalls --ghc-options="-O0 -Wall -Werror" --reorder-goals --max-backjumps=-1 ${env:CABALARGS} $PACKAGES
-            ORIGDIR=pwd
-            foreach ($dir in $PACKAGES) {
-              cd $dir
-              # cabal check -or [ "${env:CABALVER}" == "1.16" ]
-              # cabal sdist
-              # PKGVER=Invoke-Expression @'
-              #   cabal info . | ForEach-Object{($_ -split "\s+")[2]}
-        # '@
-              # SRC_TGZ=$PKGVER.tar.gz
-              # cd dist
-              # tar zxfv "$SRC_TGZ"
-              # cd "$PKGVER"
-              cabal configure --ghc-options -O0
-              cabal build
-              cd $ORIGDIR
-            }
-          }
-          default {
-            echo "invalid type ${env:BUILD}"
-            exit 1
-          }
-        }
+        stack --no-terminal --install-ghc ${env:ARGS} test --stack-yaml=stack-apps.yaml --bench --only-dependencies --test-arguments="--maximum-generated-tests=50"
       env:
         ARGS: ${{ matrix.plan.resolver }}
-        BUILD: ${{ matrix.plan.build }}
-        CABALVER: ${{ matrix.plan.cabal-install }}
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Build and test on unix
       run: |
         set -ex
-        stack --no-terminal $ARGS test --stack-yaml=stack-apps.yaml --bench --no-run-benchmarks --haddock --no-haddock-deps --test-arguments="--maximum-generated-tests=50"
+        stack --no-terminal $ARGS test --stack-yaml=stack-apps.yaml --coverage --bench --no-run-benchmarks --haddock --no-haddock-deps --test-arguments="--maximum-generated-tests=50"
         set +ex
       env:
         ARGS: ${{ matrix.plan.resolver }}
@@ -83,7 +83,7 @@ jobs:
     - name: Build and test on windows
       shell: powershell
       run: |
-        stack --no-terminal --install-ghc ${env:ARGS} test --stack-yaml=stack-apps.yaml --bench --haddock --no-haddock-deps --test-arguments="--maximum-generated-tests=50"
+        stack --no-terminal ${env:ARGS} test --stack-yaml=stack-apps.yaml --coverage --bench --no-run-benchmarks --haddock --no-haddock-deps --test-arguments="--maximum-generated-tests=50"
       env:
         ARGS: ${{ matrix.plan.resolver }}
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Build and test on windows
       shell: powershell
       run: |
-        stack --no-terminal --install-ghc ${env:ARGS} test --stack-yaml=stack-apps.yaml --bench --only-dependencies --test-arguments="--maximum-generated-tests=50"
+        stack --no-terminal --install-ghc ${env:ARGS} test --stack-yaml=stack-apps.yaml --bench --haddock --no-haddock-deps --test-arguments="--maximum-generated-tests=50"
       env:
         ARGS: ${{ matrix.plan.resolver }}
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,4 +1,4 @@
-name: HLint
+name: Haskell Linter
 
 on:
   push:
@@ -11,12 +11,14 @@ on:
       - master
 
 jobs:
-  build:
+  run:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
     steps:
     - uses: actions/checkout@v2
 
-    - name: Haskell Linter
-      uses: domdere/haskell-lint-action@v1.0.2
+    - uses: domdere/haskell-lint-action@v1.0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To some extent, these are cosmetics, but not solely. In particular, the `permissions` setting should make the Hlint CI Action work on the public repo again.

I do have some other questions on the main CI workflow file:

Should it be made much simpler by throwing out all cabal-only stuff? So, switching over to using stack for everything?

What's the role of the `test` argument here: https://github.com/jvoigtlaender/modelling-tasks-internal/blob/f90f4d1743afea42b79a48fdba258765be9a074b/.github/workflows/haskell.yml#L89 and here: https://github.com/jvoigtlaender/modelling-tasks-internal/blob/f90f4d1743afea42b79a48fdba258765be9a074b/.github/workflows/haskell.yml#L109 ?

If these commands are for installing dependencies only, there is nothing to test? Or are test suites of the dependencies run as well?

What is the rationale for the `--only-dependencies` argument here: https://github.com/jvoigtlaender/modelling-tasks-internal/blob/f90f4d1743afea42b79a48fdba258765be9a074b/.github/workflows/haskell.yml#L168 ?

It seems the following line is the "parallel" (for Unix instead of Windows) of the above, and it does not have `--only-dependencies`: https://github.com/jvoigtlaender/modelling-tasks-internal/blob/f90f4d1743afea42b79a48fdba258765be9a074b/.github/workflows/haskell.yml#L134

And in the above two lines, would it be useful to add `--coverage` after `test`?