### PR TITLE
don't produce explicit lower bound statement for objects in redundant case

### DIFF
--- a/src/Modelling/CdOd/CD2Alloy/Transform.hs
+++ b/src/Modelling/CdOd/CD2Alloy/Transform.hs
@@ -61,7 +61,7 @@ module umlp2alloy/CD#{index}Module
 
 #{template}
 #{objectsFact}
-#{limitLinks}
+#{sizeConstraints}
 #{loops}
 ///////////////////////////////////////////////////
 // Structures potentially common to multiple CDs
@@ -86,7 +86,7 @@ fact NonEmptyInstancesOnly {
     withJusts f xs
       | any isJust xs = f $ catMaybes xs
       | otherwise     = ""
-    limitLinks = withJusts (\ps -> [i|
+    sizeConstraints = withJusts (\ps -> [i|
 fact SizeConstraints {
 #{unlines ps}
 }

--- a/src/Modelling/CdOd/CD2Alloy/Transform.hs
+++ b/src/Modelling/CdOd/CD2Alloy/Transform.hs
@@ -91,18 +91,18 @@ fact LimitLinks {
 #{unlines ps}
 }
 |]) [
-      ("  #Obj >= " ++) . show <$> mlower (objects objectConfig),
-      ("  #get >= " ++) . show <$> mlower (links objectConfig),
+      ("  #Obj >= " ++) . show <$> mlower 1 (objects objectConfig),
+      ("  #get >= " ++) . show <$> mlower 0 (links objectConfig),
       ("  #get <= " ++) . show <$> snd (links objectConfig),
-      uncurry linksPerObjects $ first mlow $ linksPerObject objectConfig]
+      uncurry linksPerObjects $ first (mlow 0) $ linksPerObject objectConfig]
     linksPerObjects Nothing Nothing = Nothing
     linksPerObjects mmin mmax = Just $
       "  all o : Obj | let x = plus[#o.get,minus[#get.o,#o.get.o]] |"
       ++ maybe "" ((" x >= " ++) . show) mmin
       ++ maybe "" (const " &&") (mmin >> mmax)
       ++ maybe "" ((" x <= " ++) . show) mmax
-    mlower (x, _) = mlow x
-    mlow x = if x <= 0 then Nothing else Just x
+    mlower l = mlow l . fst
+    mlow l x = if x <= l then Nothing else Just x
     part2 = [i|
 // Concrete names of fields
 #{unlines (associationSigs associations)}

--- a/src/Modelling/CdOd/CD2Alloy/Transform.hs
+++ b/src/Modelling/CdOd/CD2Alloy/Transform.hs
@@ -87,7 +87,7 @@ fact NonEmptyInstancesOnly {
       | any isJust xs = f $ catMaybes xs
       | otherwise     = ""
     limitLinks = withJusts (\ps -> [i|
-fact LimitLinks {
+fact SizeConstraints {
 #{unlines ps}
 }
 |]) [


### PR DESCRIPTION
Issuing the statement `#Obj >= 1` is redundant due to `objectsFact` being included anyway: https://github.com/jvoigtlaender/modelling-tasks-internal/blob/6a20ef26b53af406de46bfe99462e1751a3a2bee/src/Modelling/CdOd/CD2Alloy/Transform.hs#L70-L85