### PR TITLE
reformulations in SelectValidCD feedback

### DIFF
--- a/modelling-tasks.cabal
+++ b/modelling-tasks.cabal
@@ -83,6 +83,9 @@ library
       Modelling.Types
   other-modules:
       Modelling.Auxiliary.Diagrams
+      Modelling.CdOd.Phrasing
+      Modelling.CdOd.Phrasing.English
+      Modelling.CdOd.Phrasing.German
       Modelling.PetriNet.Reach.Draw
       Modelling.PetriNet.Reach.Group
       Modelling.PetriNet.Reach.Roll

--- a/src/Modelling/Auxiliary/Common.hs
+++ b/src/Modelling/Auxiliary/Common.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Modelling.Auxiliary.Common (
   Object (..),
   Randomise (..),
@@ -84,6 +85,9 @@ data MatchListsException =
   deriving Show
 
 instance Exception MatchListsException
+
+instance MonadThrow m => MonadThrow (RandT g m) where
+  throwM = lift . throwM
 
 mapIndicesTo :: (Eq a, MonadThrow m) => [a] -> [a] -> m [(Int, Int)]
 mapIndicesTo xs ys = mapIndicesToHelper (zip [0 ..] xs) (zip [0 ..] ys)

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -80,7 +80,7 @@ import Modelling.CdOd.Types (
   linkNames,
   relationshipName,
   renameObjectsWithClassesAndLinksInOd,
-  renameClassesAndRelationshipsInCd,
+  renameClassesAndRelationships,
   reverseAssociation,
   shuffleClassAndConnectionOrder,
   shuffleObjectAndLinkOrder,
@@ -670,7 +670,7 @@ renameInstance inst names' assocs' linkNs' = do
         , a' <- BM.lookup a bmAssocs
         , l' <- BM.lookup l bmLinks
         ]
-  cd' <- renameClassesAndRelationshipsInCd bmNames bmAssocs cd
+  cd' <- renameClassesAndRelationships bmNames bmAssocs cd
   od' <- renameObjectsWithClassesAndLinksInOd bmNames bmLinks od
   shuffling <- mapM (`BM.lookup` bmLinks) $ linkShuffling inst
   return $ DifferentNamesInstance {

--- a/src/Modelling/CdOd/Generate.hs
+++ b/src/Modelling/CdOd/Generate.hs
@@ -28,7 +28,7 @@ import Modelling.CdOd.Types (
   ClassDiagram (..),
   RelationshipProperties,
   relationshipName,
-  renameClassesAndRelationshipsInCd,
+  renameClassesAndRelationships,
   )
 
 import Control.Monad.IO.Class           (MonadIO (liftIO))
@@ -66,4 +66,4 @@ instanceToCd rinsta = do
   let cns = BM.fromList $ zip (classNames cd) $ map pure ['A'..]
       relationshipNames = mapMaybe relationshipName $ relationships cd
       rns = BM.fromList $ zip relationshipNames $ map pure ['z', 'y' ..]
-  first show $ renameClassesAndRelationshipsInCd cns rns cd
+  first show $ renameClassesAndRelationships cns rns cd

--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -95,7 +95,7 @@ import Modelling.CdOd.Types (
   isObjectDiagramRandomisable,
   linkNames,
   relationshipName,
-  renameClassesAndRelationshipsInCd,
+  renameClassesAndRelationships,
   renameObjectsWithClassesAndLinksInOd,
   reverseAssociation,
   shuffleClassAndConnectionOrder,
@@ -585,7 +585,7 @@ renameInstance inst names' assocs' = do
       (names, assocs) = classAndAssocNames inst
       bmNames  = BM.fromList $ zip names names'
       bmAssocs = BM.fromList $ zip assocs assocs'
-      renameCd = renameClassesAndRelationshipsInCd bmNames bmAssocs
+      renameCd = renameClassesAndRelationships bmNames bmAssocs
       renameOd = renameObjectsWithClassesAndLinksInOd bmNames bmAssocs
   cds' <- renameCd `mapM` cds
   ods' <- mapM renameOd `mapM` ods

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -79,19 +79,20 @@ import Modelling.CdOd.MatchCdOd         (getChangesAndCds)
 import Modelling.CdOd.Output (
   cacheCd,
   )
+import Modelling.CdOd.Phrasing (
+  phraseRelationship,
+  )
 import Modelling.CdOd.RepairCd (
   AllowedProperties (..),
-  ArticleToUse (..),
   (.&.),
   allowEverything,
   checkClassConfigAndChanges,
   illegalChanges,
   legalChanges,
-  phraseRelationship,
-  phraseRelationshipDE,
   toProperty,
   )
 import Modelling.CdOd.Types (
+  ArticleToUse (..),
   Cd,
   ClassConfig (..),
   ClassDiagram (..),
@@ -343,8 +344,8 @@ toTaskTextPart output path task = case output of
       <$> M.toList (errorReasons task)
     RelationshipsList -> do
       let phrase x y z = translate $ do
-            english $ phraseRelationship DefiniteArticle x y z
-            german $ phraseRelationshipDE DefiniteArticle x y z
+            english $ phraseRelationship English DefiniteArticle x y z
+            german $ phraseRelationship German DefiniteArticle x y z
           phraseRelationship' =
             phrase (withNames task) (withDirections task)
             . (relationships (classDiagram task) !!)

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -81,13 +81,14 @@ import Modelling.CdOd.Output (
   )
 import Modelling.CdOd.RepairCd (
   AllowedProperties (..),
+  ArticleToUse (..),
   (.&.),
   allowEverything,
   checkClassConfigAndChanges,
   illegalChanges,
   legalChanges,
-  phraseRelation,
-  phraseRelationDE,
+  phraseRelationship,
+  phraseRelationshipDE,
   toProperty,
   )
 import Modelling.CdOd.Types (
@@ -342,13 +343,13 @@ toTaskTextPart output path task = case output of
       <$> M.toList (errorReasons task)
     RelationshipsList -> do
       let phrase x y z = translate $ do
-            english $ phraseRelation x y z
-            german $ phraseRelationDE x y z
-          phraseRelationship =
+            english $ phraseRelationship DefiniteArticle x y z
+            german $ phraseRelationshipDE DefiniteArticle x y z
+          phraseRelationship' =
             phrase (withNames task) (withDirections task)
             . (relationships (classDiagram task) !!)
       enumerateM (text . show)
-        $ second (phraseRelationship . snd)
+        $ second (phraseRelationship' . snd)
         <$> M.toList (relevantRelationships task)
   Translated xs -> translate $ put xs
 

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -23,6 +23,7 @@ module Modelling.CdOd.NameCdError (
   defaultNameCdErrorAnswer,
   defaultNameCdErrorConfig,
   defaultNameCdErrorInstance,
+  isRelevant,
   nameCdErrorEvaluation,
   nameCdErrorGenerate,
   nameCdErrorSolution,

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -191,6 +191,7 @@ data NumberOfReasons = NumberOfReasons {
 
 data NameCdErrorConfig = NameCdErrorConfig {
   allowedProperties           :: AllowedProperties,
+  articleToUse                :: ArticleToUse,
   classConfig                 :: ClassConfig,
   maxInstances                :: Maybe Integer,
   objectProperties            :: ObjectProperties,
@@ -209,6 +210,7 @@ defaultNameCdErrorConfig = NameCdErrorConfig {
     reverseInheritances = False,
     Modelling.CdOd.RepairCd.selfInheritances = False
     },
+  articleToUse = DefiniteArticle,
   classConfig = ClassConfig {
     classLimits = (4, 4),
     aggregationLimits = (1, Just 1),
@@ -713,9 +715,9 @@ nameCdErrorGenerate
   -> Int
   -> Int
   -> IO NameCdErrorInstance
-nameCdErrorGenerate inst segment seed = do
+nameCdErrorGenerate config segment seed = do
   let g = mkStdGen $ (segment +) $ 4 * seed
-  flip evalRandT g $ generateAndRandomise inst
+  flip evalRandT g $ generateAndRandomise config
 
 generateAndRandomise
   :: RandomGen g
@@ -759,7 +761,7 @@ generateAndRandomise NameCdErrorConfig {..} = do
       annotation = Relevant {
         contributingToProblem = x `elem` xs,
         listingPriority = n,
-        referenceUsing = DefiniteArticle
+        referenceUsing = articleToUse
         }
       }
     toTranslations x = case x of

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -685,9 +685,16 @@ nameCdErrorGenerate
   -> Int
   -> Int
   -> IO NameCdErrorInstance
-nameCdErrorGenerate NameCdErrorConfig {..} segment seed = do
+nameCdErrorGenerate inst segment seed = do
   let g = mkStdGen $ (segment +) $ 4 * seed
-  (cd, reason, rs) <- flip evalRandT g $ nameCdError
+  flip evalRandT g $ generateAndRandomise inst
+
+generateAndRandomise
+  :: RandomGen g
+  => NameCdErrorConfig
+  -> RandT g IO NameCdErrorInstance
+generateAndRandomise NameCdErrorConfig {..} = do
+  (cd, reason, rs) <- nameCdError
     allowedProperties
     classConfig
     objectProperties

--- a/src/Modelling/CdOd/Phrasing.hs
+++ b/src/Modelling/CdOd/Phrasing.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE LambdaCase #-}
+-- | provide phrasing functions for different languages
+module Modelling.CdOd.Phrasing (
+  phraseChange,
+  phraseRelationship,
+  trailingCommaGerman,
+  ) where
+
+import qualified Modelling.CdOd.Phrasing.German    as German
+import qualified Modelling.CdOd.Phrasing.English   as English
+
+import Control.Monad.Output (
+  Language (English, German),
+  )
+
+import Modelling.Types (
+  Change,
+  )
+import Modelling.CdOd.Types (
+  ArticleToUse,
+  Relationship,
+  )
+
+phraseChange :: Language
+  -> ArticleToUse
+  -> Bool
+  -> Bool
+  -> Change (Relationship String String)
+  -> String
+phraseChange = \case
+  English -> English.phraseChange
+  German -> German.phraseChange
+
+phraseRelationship
+  :: Language
+  -> ArticleToUse
+  -> Bool
+  -> Bool
+  -> Relationship String String -> String
+phraseRelationship = \case
+  English -> English.phraseRelationship
+  German -> German.phraseRelationship
+
+trailingCommaGerman :: String -> String
+trailingCommaGerman = German.trailingComma

--- a/src/Modelling/CdOd/Phrasing/English.hs
+++ b/src/Modelling/CdOd/Phrasing/English.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+-- | Phrasing relationships and changes in English
+module Modelling.CdOd.Phrasing.English (
+  phraseChange,
+  phraseRelationship,
+  ) where
+
+import Modelling.Types (
+  Change (..),
+  )
+import Modelling.CdOd.Types (
+  ArticleToUse (..),
+  LimitedLinking (..),
+  NonInheritancePhrasing (..),
+  Relationship (..),
+  toPhrasing,
+  )
+
+import Data.String.Interpolate          (iii)
+
+phraseChange
+  :: ArticleToUse
+  -> Bool
+  -> Bool
+  -> Change (Relationship String String)
+  -> String
+phraseChange article byName withDir c = case (add c, remove c) of
+  (Nothing, Nothing) -> "change nothing"
+  (Just e,  Nothing) -> "add " ++ phrasingNew e
+  (Nothing, Just e ) -> "remove " ++ phrasingOld e
+  (Just e1, Just e2) ->
+    "replace " ++ phrasingOld e2
+    ++ " by " ++ phrasingNew e1
+  where
+    phrasingOld = phraseRelation article $ toPhrasing byName withDir
+    phrasingNew = phraseRelation IndefiniteArticle $ toPhrasing False withDir
+
+consonantArticle :: ArticleToUse -> String
+consonantArticle = \case
+  DefiniteArticle -> "the"
+  IndefiniteArticle -> "a"
+
+vowelArticle :: ArticleToUse -> String
+vowelArticle = \case
+  DefiniteArticle -> "the"
+  IndefiniteArticle -> "an"
+
+phraseRelationship
+  :: ArticleToUse
+  -> Bool
+  -> Bool
+  -> Relationship String String
+  -> String
+phraseRelationship article byName withDir = phraseRelation article phrasing
+  where
+    phrasing = toPhrasing byName withDir
+
+phraseRelation
+  :: ArticleToUse
+  -> NonInheritancePhrasing
+  -> Relationship String String
+  -> String
+phraseRelation article _ Inheritance {..} = [iii|
+  #{vowelArticle article} inheritance
+  where #{subClass} inherits from #{superClass}
+  |]
+phraseRelation _ ByName Association {..} = "association " ++ associationName
+phraseRelation _ ByName Aggregation {..} = "aggregation " ++ aggregationName
+phraseRelation _ ByName Composition {..} = "composition " ++ compositionName
+phraseRelation article Lengthy Association {..}
+  | associationFrom == associationTo = [iii|
+    #{consonantArticle article} self-association for #{linking associationFrom}
+    where #{participates (limits associationFrom) "it"} at one end
+    and #{phraseLimit $ limits associationTo} at the other end
+    |]
+  | otherwise  = [iii|
+    #{vowelArticle article} association
+    #{participations associationFrom associationTo}
+    |]
+phraseRelation article ByDirection Association {..}
+  | associationFrom == associationTo = [iii|
+    #{consonantArticle article} self-association for #{linking associationFrom}
+    where #{participates (limits associationFrom) "it"} at its beginning
+    and #{phraseLimit $ limits associationTo} at its arrow end
+    |]
+  | otherwise = [iii|
+    #{vowelArticle article} association from #{linking associationFrom}
+    to #{linking associationTo}
+    #{participations associationFrom associationTo}
+    |]
+phraseRelation article _ Aggregation {..}
+  | aggregationPart == aggregationWhole = [iii|
+    #{consonantArticle article} self-aggregation
+    #{selfParticipatesPartWhole aggregationPart aggregationWhole}
+    |]
+  | otherwise = [iii|
+    #{consonantArticle article} relationship
+    that makes #{linking aggregationWhole}
+    an aggregation of #{linking aggregationPart}s
+    #{participations aggregationWhole aggregationPart}
+    |]
+phraseRelation article _ Composition {..}
+  | compositionPart == compositionWhole = [iii|
+    #{consonantArticle article} self-composition
+    #{selfParticipatesPartWhole compositionPart compositionWhole}
+    |]
+  | otherwise = [iii|
+    #{consonantArticle article} relationship
+    that makes #{linking compositionWhole}
+    a composition of #{linking compositionPart}s
+    #{participations compositionWhole compositionPart}
+    |]
+
+selfParticipatesPartWhole
+  :: LimitedLinking String
+  -> LimitedLinking String
+  -> String
+selfParticipatesPartWhole part whole = [iii|
+  for #{linking part} where #{participates (limits part) "it"} as part
+  and #{phraseLimit $ limits whole} as whole|]
+
+participations
+  :: LimitedLinking String
+  -> LimitedLinking String
+  -> String
+participations from to = [iii|
+  where #{participates (limits from) (linking from)}
+  and #{participates (limits to) (linking to)}
+  |]
+
+participates :: (Int, Maybe Int) -> String -> String
+participates r c = c ++ " participates " ++ phraseLimit r
+
+phraseLimit :: (Int, Maybe Int) -> String
+phraseLimit (0, Just 0)  = "not at all"
+phraseLimit (1, Just 1)  = "exactly once"
+phraseLimit (2, Just 2)  = "exactly twice"
+phraseLimit (-1, Just n) = "*.." ++ show n ++ " times"
+phraseLimit (m, Nothing) = show m ++ "..* times"
+phraseLimit (m, Just n)  = show m ++ ".." ++ show n ++ " times"

--- a/src/Modelling/CdOd/Phrasing/German.hs
+++ b/src/Modelling/CdOd/Phrasing/German.hs
@@ -88,7 +88,7 @@ phraseRelation article ByDirection Association {..}
     und am Ende #{phraseLimit $ limits associationTo} beteiligt ist
     |]
   | otherwise = [iii|
-    #{femaleArticle article} Assocziation von #{linking associationFrom}
+    #{femaleArticle article} Assoziation von #{linking associationFrom}
     nach #{linking associationTo}
     |] ++ participations associationFrom associationTo
 phraseRelation article _ Aggregation {..}

--- a/src/Modelling/CdOd/Phrasing/German.hs
+++ b/src/Modelling/CdOd/Phrasing/German.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+-- | Phrasing relationships and changes in German
+module Modelling.CdOd.Phrasing.German (
+  phraseChange,
+  phraseRelationship,
+  trailingComma,
+  ) where
+
+import Modelling.Types (
+  Change (..),
+  )
+import Modelling.CdOd.Types (
+  ArticleToUse (..),
+  LimitedLinking (..),
+  NonInheritancePhrasing (..),
+  Relationship (..),
+  toPhrasing,
+  )
+
+import Data.String.Interpolate          (iii)
+
+phraseChange
+  :: ArticleToUse
+  -> Bool
+  -> Bool
+  -> Change (Relationship String String)
+  -> String
+phraseChange article byName withDir c = case (add c, remove c) of
+  (Nothing, Nothing) -> "verändere nichts"
+  (Just a,  Nothing) -> "ergänze "
+    ++ trailingComma (phrasingNew a)
+  (Nothing, Just e)  -> "entferne " ++ phrasingOld e
+  (Just a,  Just e)  ->
+    "ersetze " ++ trailingComma (phrasingOld e)
+    ++ " durch " ++ phrasingNew a
+  where
+    phrasingOld = phraseRelation article $ toPhrasing byName withDir
+    phrasingNew = phraseRelation IndefiniteArticle $ toPhrasing False withDir
+
+trailingComma :: String -> String
+trailingComma xs
+      | ',' `elem` xs = xs ++ ","
+      | otherwise     = xs
+
+femaleArticle :: ArticleToUse -> String
+femaleArticle = \case
+  DefiniteArticle -> "die"
+  IndefiniteArticle -> "eine"
+
+phraseRelationship
+  :: ArticleToUse
+  -> Bool
+  -> Bool
+  -> Relationship String String
+  -> String
+phraseRelationship article byName withDir = phraseRelation article phrasing
+  where
+    phrasing = toPhrasing byName withDir
+
+phraseRelation
+  :: ArticleToUse
+  -> NonInheritancePhrasing
+  -> Relationship String String
+  -> String
+phraseRelation article _ Inheritance {..} = [iii|
+  #{femaleArticle article} Vererbung,
+  bei der #{subClass} von #{superClass} erbt
+  |]
+phraseRelation _ ByName Association {..} = "Assoziation " ++ associationName
+phraseRelation _ ByName Aggregation {..} = "Aggregation " ++ aggregationName
+phraseRelation _ ByName Composition {..} = "Komposition " ++ compositionName
+phraseRelation article Lengthy Association {..}
+  | linking associationFrom == linking associationTo = [iii|
+    #{femaleArticle article} Selbst-Assoziation für #{linking associationFrom},
+    bei der #{linking associationFrom}
+    an einem Ende #{phraseLimit $ limits associationFrom}
+    und am anderen Ende #{phraseLimit $ limits associationTo} beteiligt ist
+    |]
+  | otherwise = femaleArticle article ++ " Assoziation"
+      ++ participations associationFrom associationTo
+phraseRelation article ByDirection Association {..}
+  | associationFrom == associationTo = [iii|
+    #{femaleArticle article} Selbst-Assoziation für #{linking associationFrom},
+    bei der {linking associationFrom}
+    am Anfang #{phraseLimit $ limits associationFrom}
+    und am Ende #{phraseLimit $ limits associationTo} beteiligt ist
+    |]
+  | otherwise = [iii|
+    #{femaleArticle article} Assocziation von #{linking associationFrom}
+    nach #{linking associationTo}
+    |] ++ participations associationFrom associationTo
+phraseRelation article _ Aggregation {..}
+  | aggregationPart == aggregationWhole = [iii|
+    #{femaleArticle article} Selbst-Aggregation
+    #{selfParticipatesPartWhole aggregationPart aggregationWhole}
+    |]
+  | otherwise = [iii|
+    #{femaleArticle article} Beziehung, die #{linking aggregationWhole}
+    eine Aggregation aus #{linking aggregationPart}s macht
+    |] ++ participations aggregationWhole aggregationPart
+phraseRelation article _ Composition {..}
+  | compositionPart == compositionWhole = [iii|
+    #{femaleArticle article} Selbst-Komposition
+    #{selfParticipatesPartWhole compositionPart compositionWhole}
+    |]
+  | otherwise = [iii|
+    #{femaleArticle article} Beziehung, die #{linking compositionWhole}
+    eine Komposition aus #{linking compositionPart}s macht
+    |] ++ participations compositionWhole compositionPart
+
+selfParticipatesPartWhole
+  :: LimitedLinking String
+  -> LimitedLinking String
+  -> String
+selfParticipatesPartWhole part whole = [iii|
+  für #{linking part}, wobei #{linking part} #{phraseLimit $ limits part}
+  als Teil and #{phraseLimit $ limits whole} als Ganzes beteiligt ist
+  |]
+
+participations
+  :: LimitedLinking String
+  -> LimitedLinking String
+  -> String
+participations from to = [iii|
+  , wobei #{linking from} #{phraseLimit $ limits from}
+  und #{linking to} #{phraseLimit $ limits to} beteiligt ist
+  |]
+
+phraseLimit :: (Int, Maybe Int) -> String
+phraseLimit (0, Just 0)  = "gar nicht"
+phraseLimit (1, Just 1)  = "genau einmal"
+phraseLimit (2, Just 2)  = "genau zweimal"
+phraseLimit (-1, Just n) = "*.." ++ show n ++ "-mal"
+phraseLimit (m, Nothing) = show m ++ "..*-mal"
+phraseLimit (m, Just n)  = show m ++ ".." ++ show n ++ "-mal"

--- a/src/Modelling/CdOd/RepairCd.hs
+++ b/src/Modelling/CdOd/RepairCd.hs
@@ -98,8 +98,7 @@ import Modelling.CdOd.Types (
   defaultProperties,
   maxObjects,
   relationshipName,
-  renameClassesAndRelationshipsInCd,
-  renameClassesAndRelationshipsInRelationship,
+  renameClassesAndRelationships,
   reverseAssociation,
   shuffleClassAndConnectionOrder,
   )
@@ -453,8 +452,8 @@ renameInstance inst names' assocs' = do
   let (names, assocs) = classAndAssocNames inst
       bmNames  = BM.fromList $ zip names names'
       bmAssocs = BM.fromList $ zip assocs assocs'
-      renameCd = renameClassesAndRelationshipsInCd bmNames bmAssocs
-      renameEdge = renameClassesAndRelationshipsInRelationship bmNames bmAssocs
+      renameCd = renameClassesAndRelationships bmNames bmAssocs
+      renameEdge = renameClassesAndRelationships bmNames bmAssocs
   cd <- renameCd $ classDiagram inst
   chs <- mapM (mapInValidOptionM (mapM renameEdge) renameCd renameCd)
     $ changes inst

--- a/src/Modelling/CdOd/SelectValidCd.hs
+++ b/src/Modelling/CdOd/SelectValidCd.hs
@@ -416,8 +416,8 @@ shuffleInstance
   :: MonadRandom m
   => SelectValidCdInstance
   -> m SelectValidCdInstance
-shuffleInstance inst = SelectValidCdInstance
-  <$> (M.fromAscList . zipWith replaceId [1..]
+shuffleInstance inst =
+  (SelectValidCdInstance . M.fromAscList . zipWith replaceId [1..]
        <$> shuffleM (M.toList $ classDiagrams inst))
   <*> pure (showExtendedFeedback inst)
   <*> pure (showSolution inst)

--- a/src/Modelling/CdOd/SelectValidCd.hs
+++ b/src/Modelling/CdOd/SelectValidCd.hs
@@ -75,8 +75,7 @@ import Modelling.CdOd.Types (
   linkNames,
   shuffleClassAndConnectionOrder,
   relationshipName,
-  renameClassesAndRelationshipsInCd,
-  renameClassesAndRelationshipsInRelationship,
+  renameClassesAndRelationships,
   renameObjectsWithClassesAndLinksInOd,
   shuffleObjectAndLinkOrder,
   )
@@ -392,9 +391,9 @@ shuffleEach inst@SelectValidCdInstance {..} = do
   assocs' <- shuffleM assocs
   let bmNames  = BM.fromList $ zip names names'
       bmAssocs = BM.fromList $ zip assocs assocs'
-      renameCd = renameClassesAndRelationshipsInCd bmNames bmAssocs
+      renameCd = renameClassesAndRelationships bmNames bmAssocs
       renameOd = renameObjectsWithClassesAndLinksInOd bmNames bmAssocs
-      renameEdge = renameClassesAndRelationshipsInRelationship bmNames bmAssocs
+      renameEdge = renameClassesAndRelationships bmNames bmAssocs
   cds <- mapInValidOptionM renameCd (mapM renameEdge) renameOd
     `mapM` classDiagrams
   return $ SelectValidCdInstance {
@@ -442,8 +441,8 @@ renameInstance inst names' assocs' = do
   let (names, assocs) = classAndAssocNames inst
       bmNames  = BM.fromList $ zip names names'
       bmAssocs = BM.fromList $ zip assocs assocs'
-      renameCd = renameClassesAndRelationshipsInCd bmNames bmAssocs
-      renameEdge = renameClassesAndRelationshipsInRelationship bmNames bmAssocs
+      renameCd = renameClassesAndRelationships bmNames bmAssocs
+      renameEdge = renameClassesAndRelationships bmNames bmAssocs
       renameOd = renameObjectsWithClassesAndLinksInOd bmNames bmAssocs
   cds <- mapM
     (mapInValidOptionM renameCd (mapM renameEdge) renameOd)

--- a/src/Modelling/CdOd/SelectValidCd.hs
+++ b/src/Modelling/CdOd/SelectValidCd.hs
@@ -45,23 +45,23 @@ import Modelling.Auxiliary.Output (
 import Modelling.CdOd.CdAndChanges.Instance (
   ChangeAndCd (..),
   )
+import Modelling.CdOd.Phrasing (
+  phraseChange,
+  phraseRelationship,
+  trailingCommaGerman,
+  )
 import Modelling.CdOd.RepairCd (
   AllowedProperties (..),
-  ArticleToUse (DefiniteArticle),
   InValidOption (..),
   allowEverything,
   checkClassConfigAndChanges,
   mapInValidOption,
   mapInValidOptionM,
-  phraseChange,
-  phraseChangeDE,
-  phraseRelationship,
-  phraseRelationshipDE,
   repairIncorrect,
-  trailingCommaDE,
   )
 import Modelling.CdOd.Output            (cacheCd, cacheOd)
 import Modelling.CdOd.Types (
+  ArticleToUse (DefiniteArticle),
   Cd,
   ClassConfig (..),
   ClassDiagram (..),
@@ -283,25 +283,27 @@ selectValidCdFeedback path withDir byName xs x cdChange =
             Class diagram #{x} is in fact invalid.
             Consider the following change, which aims at fixing a
             problematic situation within the given class diagram:
-            #{phraseChange DefiniteArticle byName withDir change}.
+            #{phraseChange English DefiniteArticle byName withDir change}.
             |]
           german [iii|
             Klassendiagramm #{x} ist ungültig.
             Sehen Sie sich die folgende Änderung an, die darauf abzielt, eine
             problematische Stelle im Klassendiagramm zu beheben:
-            #{phraseChangeDE DefiniteArticle byName withDir change}.
+            #{phraseChange German DefiniteArticle byName withDir change}.
             |]
         Just relation -> do
+          let phrase l =
+                phraseRelationship l DefiniteArticle byName withDir relation
           english [iii|
             Class diagram #{x} is in fact invalid.
             If there would not be
-            #{phraseRelationship DefiniteArticle byName withDir relation},
+            #{phrase English},
             it would be valid.
             |]
           german [iii|
             Klassendiagramm #{x} ist ungültig.
             Wenn es
-            #{trailingCommaDE $ phraseRelationshipDE DefiniteArticle byName withDir relation}
+            #{trailingCommaGerman $ phrase German}
             nicht gäbe, wäre es gültig.
             |]
       pure ()

--- a/src/Modelling/CdOd/SelectValidCd.hs
+++ b/src/Modelling/CdOd/SelectValidCd.hs
@@ -47,6 +47,7 @@ import Modelling.CdOd.CdAndChanges.Instance (
   )
 import Modelling.CdOd.RepairCd (
   AllowedProperties (..),
+  ArticleToUse (DefiniteArticle),
   InValidOption (..),
   allowEverything,
   checkClassConfigAndChanges,
@@ -54,8 +55,8 @@ import Modelling.CdOd.RepairCd (
   mapInValidOptionM,
   phraseChange,
   phraseChangeDE,
-  phraseRelation,
-  phraseRelationDE,
+  phraseRelationship,
+  phraseRelationshipDE,
   repairIncorrect,
   trailingCommaDE,
   )
@@ -282,25 +283,25 @@ selectValidCdFeedback path withDir byName xs x cdChange =
             Class diagram #{x} is in fact invalid.
             Consider the following change, which aims at fixing a
             problematic situation within the given class diagram:
-            #{phraseChange byName withDir change}.
+            #{phraseChange DefiniteArticle byName withDir change}.
             |]
           german [iii|
             Klassendiagramm #{x} ist ungültig.
             Sehen Sie sich die folgende Änderung an, die darauf abzielt, eine
             problematische Stelle im Klassendiagramm zu beheben:
-            #{phraseChangeDE byName withDir change}.
+            #{phraseChangeDE DefiniteArticle byName withDir change}.
             |]
         Just relation -> do
           english [iii|
             Class diagram #{x} is in fact invalid.
             If there would not be
-            #{phraseRelation byName withDir relation},
+            #{phraseRelationship DefiniteArticle byName withDir relation},
             it would be valid.
             |]
           german [iii|
             Klassendiagramm #{x} ist ungültig.
             Wenn es
-            #{trailingCommaDE $ phraseRelationDE byName withDir relation}
+            #{trailingCommaDE $ phraseRelationshipDE DefiniteArticle byName withDir relation}
             nicht gäbe, wäre es gültig.
             |]
       pure ()

--- a/src/Modelling/CdOd/SelectValidCd.hs
+++ b/src/Modelling/CdOd/SelectValidCd.hs
@@ -114,6 +114,7 @@ import System.Random.Shuffle            (shuffleM)
 
 data SelectValidCdConfig = SelectValidCdConfig {
     allowedProperties :: AllowedProperties,
+    articleToUse      :: ArticleToUse,
     classConfig      :: ClassConfig,
     maxInstances     :: Maybe Integer,
     objectProperties :: ObjectProperties,
@@ -138,6 +139,7 @@ defaultSelectValidCdConfig = SelectValidCdConfig {
         wrongAssociationLimits = False,
         wrongCompositionLimits = False
         },
+    articleToUse = DefiniteArticle,
     classConfig = ClassConfig {
         classLimits        = (4, 4),
         aggregationLimits  = (0, Just 0),
@@ -347,6 +349,7 @@ selectValidCd config segment seed = do
     (allowedProperties config)
     (classConfig config)
     (objectProperties config)
+    (articleToUse config)
     (maxInstances config)
     (timeout config)
   let cds = map (mapInValidOption annotatedChangeClassDiagram id id) chs

--- a/src/Modelling/CdOd/SelectValidCd.hs
+++ b/src/Modelling/CdOd/SelectValidCd.hs
@@ -286,7 +286,7 @@ selectValidCdFeedback path withDir byName xs x cdChange =
             |]
           german [iii|
             Klassendiagramm #{x} ist ungültig.
-            Sehen Sie sich die folgende Änderung an, die darauf abzielt eine
+            Sehen Sie sich die folgende Änderung an, die darauf abzielt, eine
             problematische Stelle im Klassendiagramm zu beheben:
             #{phraseChangeDE byName withDir change}.
             |]
@@ -294,7 +294,7 @@ selectValidCdFeedback path withDir byName xs x cdChange =
           english [iii|
             Class diagram #{x} is in fact invalid.
             If there would not be
-            #{phraseRelation byName withDir relation}
+            #{phraseRelation byName withDir relation},
             it would be valid.
             |]
           german [iii|
@@ -309,13 +309,13 @@ selectValidCdFeedback path withDir byName xs x cdChange =
       paragraph $ translate $ do
         english [iii|
           Class diagram #{x} is in fact valid.
-          Consider the following object diagram, which is an instance of the
+          Consider the following object diagram, which is an instance of this
           class diagram:
           |]
         german [iii|
           Klassendiagramm #{x} ist gültig.
           Betrachten Sie zum Beispiel das folgende Objektdiagramm,
-          das Instanz des Klassendiagramms ist:
+          das Instanz dieses Klassendiagramms ist:
           |]
       paragraph $ image $=<< liftIO
         $ flip evalRandT (mkStdGen 0)

--- a/src/Modelling/CdOd/SelectValidCd.hs
+++ b/src/Modelling/CdOd/SelectValidCd.hs
@@ -299,8 +299,7 @@ selectValidCdFeedback path withDir byName xs x cdChange =
                 phraseRelationship l article byName withDir relation
           english [iii|
             Class diagram #{x} is in fact invalid.
-            If there would not be
-            #{phrase English},
+            If #{phrase English} would not be there,
             it would be valid.
             |]
           german [iii|

--- a/src/Modelling/CdOd/Types.hs
+++ b/src/Modelling/CdOd/Types.hs
@@ -44,6 +44,10 @@ module Modelling.CdOd.Types (
   shuffleObjectAndLinkOrder,
   toPropertySet,
   towardsValidProperties,
+  -- * Phrasing
+  ArticleToUse (..),
+  NonInheritancePhrasing (..),
+  toPhrasing,
   ) where
 
 
@@ -790,3 +794,19 @@ shouldBeThick a b classesWithSubclasses =
             in (one && (two || b `isSubOf` b') || two && (one || a `isSubOf` a'))
       )
   where x `isSubOf` y = x `elem` fromJust (lookup y classesWithSubclasses)
+
+data ArticleToUse
+  = DefiniteArticle
+  | IndefiniteArticle
+
+data NonInheritancePhrasing
+  = ByDirection
+  | ByName
+  | Lengthy
+  -- ^ Associations are phrased lengthy, others as by direction
+
+toPhrasing :: Bool -> Bool -> NonInheritancePhrasing
+toPhrasing byName withDir
+  | byName = ByName
+  | withDir = ByDirection
+  | otherwise = Lengthy

--- a/src/Modelling/PetriNet/Diagram.hs
+++ b/src/Modelling/PetriNet/Diagram.hs
@@ -234,7 +234,9 @@ drawNode hidePName _ pfont (l, Just i) p
     emptyPlace = circle 20 # lwL 0.5 # named l # svgClass "node"
     label
       | hidePName = mempty
-      | otherwise = center (text' pfont 18 l) # translate (r2 (0, -3 * spacer)) # svgClass "nlabel"
+      | otherwise = center (text' pfont 18 l)
+        # translate (r2 (0, - (3 * spacer)))
+        # svgClass "nlabel"
     tokenGrey = sRGB24 136 136 136
     token = circle 4.5 # lc tokenGrey # fc tokenGrey # lwL 0 # svgClass "token"
     placeToken j = token

--- a/test/Modelling/CdOd/NameCdErrorSpec.hs
+++ b/test/Modelling/CdOd/NameCdErrorSpec.hs
@@ -4,14 +4,18 @@ import qualified Data.Map                         as M (null)
 
 import Modelling.CdOd.NameCdError (
   NameCdErrorConfig (timeout),
-  NameCdErrorInstance (errorReasons, relevantRelationships),
+  NameCdErrorInstance (classDiagram, errorReasons),
   checkNameCdErrorConfig,
   checkNameCdErrorInstance,
   classAndAssocNames,
   defaultNameCdErrorConfig,
   defaultNameCdErrorInstance,
+  isRelevant,
   renameInstance,
   nameCdErrorGenerate,
+  )
+import Modelling.CdOd.Types (
+  AnnotatedClassDiagram (annotatedRelationships),
   )
 import Modelling.Auxiliary.Common       (oneOf)
 
@@ -33,7 +37,7 @@ spec = do
         do
           segment <- oneOf [0 .. 3]
           seed <- randomIO
-          let check x = not (M.null $ relevantRelationships x)
+          let check x = any isRelevant (annotatedRelationships $ classDiagram x)
                 && not (M.null $ errorReasons x)
           check <$> nameCdErrorGenerate cfg segment seed
         `shouldReturn` True


### PR DESCRIPTION
Ich fände darüber hinaus auch noch andere Umformulierungen sinnvoll, die ich aber nicht direkt umsetzen konnte (und die wahrscheinlich auch Auswirkungen auf andere Aufgabentypen hätte).

Und zwar scheint mir bei Bezugnahme auf eine Beziehung in konkretem Klassendiagramm die Verwendung bestimmter Artikel sinnvoller.

Zum Beispiel in 

![image](https://github.com/jvoigtlaender/modelling-tasks-internal/assets/5853832/ebc0e687-1f14-4864-b968-b7668f274fb8)

würde ich "If there would not be the inheritance where C inherits from B it would be valid." vorschlagen, und in

![image](https://github.com/jvoigtlaender/modelling-tasks-internal/assets/5853832/34d12c51-3cd7-4fbc-ba6b-ff7b4eb6ae81)

entsprechend "Wenn es die Vererbung, ...".

Ich weiß nicht, ob dies lokal geht, oder eine Erweiterung von `phraseRelation` um einen Parameter erfordert, da an anderer Stelle ja wahrscheinlich die Verwendung unbestimmter Artikel besser bleibt (etwa in `RepairValidCD` etwas in der Art, "wenn man *die* Beziehung so-und-so durch *eine* Beziehung so-und-so ersetzen würde, ...").