### PR TITLE
separate names for different Petri instances

### DIFF
--- a/src/Modelling/PetriNet/Concurrency.hs
+++ b/src/Modelling/PetriNet/Concurrency.hs
@@ -136,6 +136,7 @@ import Control.Monad.Random (
   )
 import Control.Monad.Trans              (MonadTrans (lift))
 import Data.Bifunctor                   (Bifunctor (bimap))
+import Data.Data                        (Data, Typeable)
 import Data.Either                      (isLeft)
 import Data.GraphViz.Commands           (GraphvizCommand (Circo, Fdp))
 import Data.String.Interpolate          (i, iii)
@@ -158,12 +159,16 @@ simpleFindConcurrencyTask = findConcurrencyTask
 
 findConcurrencyTask
   :: (
+    Data (n String),
+    Data (p n String),
     MonadCache m,
     MonadDiagrams m,
     MonadGraphviz m,
     MonadThrow m,
     Net p n,
-    OutputCapable m
+    OutputCapable m,
+    Typeable n,
+    Typeable p
     )
   => FilePath
   -> FindInstance (p n String) (Concurrent Transition)
@@ -259,12 +264,16 @@ simplePickConcurrencyTask = pickConcurrencyTask
 
 pickConcurrencyTask
   :: (
+    Data (n String),
+    Data (p n String),
     MonadCache m,
     MonadDiagrams m,
     MonadGraphviz m,
     MonadThrow m,
     Net p n,
-    OutputCapable m
+    OutputCapable m,
+    Typeable n,
+    Typeable p
     )
   => FilePath
   -> PickInstance (p n String)

--- a/src/Modelling/PetriNet/Conflict.hs
+++ b/src/Modelling/PetriNet/Conflict.hs
@@ -161,6 +161,7 @@ import Control.Monad.Trans              (MonadTrans (lift))
 import Data.Bifunctor                   (Bifunctor (bimap))
 import Data.Bitraversable               (Bitraversable (bitraverse))
 import Data.Bool                        (bool)
+import Data.Data                        (Data, Typeable)
 import Data.Either                      (isLeft)
 import Data.Function                    ((&))
 import Data.Foldable                    (for_)
@@ -188,12 +189,16 @@ simpleFindConflictTask = findConflictTask
 
 findConflictTask
   :: (
+    Data (n String),
+    Data (p n String),
     MonadCache m,
     MonadDiagrams m,
     MonadGraphviz m,
     MonadThrow m,
     Net p n,
-    OutputCapable m
+    OutputCapable m,
+    Typeable n,
+    Typeable p
     )
   => FilePath
   -> FindInstance (p n String) Conflict
@@ -310,12 +315,16 @@ simplePickConflictTask = pickConflictTask
 
 pickConflictTask
   :: (
+    Data (n String),
+    Data (p n String),
     MonadCache m,
     MonadDiagrams m,
     MonadGraphviz m,
     MonadThrow m,
     Net p n,
-    OutputCapable m
+    OutputCapable m,
+    Typeable n,
+    Typeable p
     )
   => FilePath
   -> PickInstance (p n String)

--- a/src/Modelling/PetriNet/ConflictPlaces.hs
+++ b/src/Modelling/PetriNet/ConflictPlaces.hs
@@ -77,6 +77,7 @@ import Control.OutputCapable.Blocks (
   translate,
   )
 import Data.Bifunctor                   (Bifunctor (bimap))
+import Data.Data                        (Data, Typeable)
 import Data.Function                    ((&))
 import Data.Foldable                    (for_)
 import Data.GraphViz.Commands           (GraphvizCommand (Circo))
@@ -105,12 +106,16 @@ simpleFindConflictPlacesTask = findConflictPlacesTask
 
 findConflictPlacesTask
   :: (
+    Data (n String),
+    Data (p n String),
     MonadCache m,
     MonadDiagrams m,
     MonadGraphviz m,
     MonadThrow m,
     Net p n,
-    OutputCapable m
+    OutputCapable m,
+    Typeable n,
+    Typeable p
     )
   => FilePath
   -> FindInstance (p n String) Conflict

--- a/src/Modelling/PetriNet/MatchToMath.hs
+++ b/src/Modelling/PetriNet/MatchToMath.hs
@@ -125,6 +125,7 @@ import Control.Monad.Random             (
 import Data.Bifoldable                  (Bifoldable (bifoldMap))
 import Data.Bifunctor                   (Bifunctor (bimap, second))
 import Data.Bitraversable               (Bitraversable (bitraverse), bimapM)
+import Data.Data                        (Data, Typeable)
 import Data.GraphViz                    (GraphvizCommand (Circo, Dot, Fdp, Sfdp))
 import Data.Map                         (Map, fromList, mapWithKey, toList)
 import Data.String.Interpolate          (i)
@@ -214,14 +215,34 @@ evalWithStdGen
 evalWithStdGen = flip evalRandT . mkStdGen
 
 writeDia
-  :: (MonadCache m, MonadDiagrams m, MonadGraphviz m, MonadThrow m, Net p n)
+  :: (
+    Data (n String),
+    Data (p n String),
+    MonadCache m,
+    MonadDiagrams m,
+    MonadGraphviz m,
+    MonadThrow m,
+    Net p n,
+    Typeable n,
+    Typeable p
+    )
   => FilePath
   -> MatchInstance (Drawable (p n String)) b
   -> m (MatchInstance FilePath b)
 writeDia path = bimapM (\(n, ds) -> writeGraph ds path n) pure
 
 writeDias
-  :: (MonadCache m, MonadDiagrams m, MonadGraphviz m, MonadThrow m, Net p n)
+  :: (
+    Data (n String),
+    Data (p n String),
+    MonadCache m,
+    MonadDiagrams m,
+    MonadGraphviz m,
+    MonadThrow m,
+    Net p n,
+    Typeable n,
+    Typeable p
+    )
   => FilePath
   -> MatchInstance a (Drawable (p n String))
   -> m (MatchInstance a FilePath)
@@ -233,7 +254,17 @@ writeDias path inst =
   in bimapM pure (\(_, (n, d)) -> writeGraph d path n) inst'
 
 writeGraph
-  :: (MonadCache m, MonadDiagrams m, MonadGraphviz m, MonadThrow m, Net p n)
+  :: (
+    Data (n String),
+    Data (p n String),
+    MonadCache m,
+    MonadDiagrams m,
+    MonadGraphviz m,
+    MonadThrow m,
+    Net p n,
+    Typeable n,
+    Typeable p
+    )
   => DrawSettings
   -> FilePath
   -> p n String

--- a/src/Modelling/PetriNet/Pick.hs
+++ b/src/Modelling/PetriNet/Pick.hs
@@ -71,6 +71,7 @@ import Control.Monad.Random (
 import Control.Monad.Trans              (MonadTrans (lift))
 import Data.Bitraversable               (bimapM)
 import Data.Containers.ListUtils        (nubOrd)
+import Data.Data                        (Data, Typeable)
 import Data.Map                         (Map)
 import Data.Maybe                       (isJust)
 import GHC.Generics                     (Generic)
@@ -170,8 +171,18 @@ pickSolution :: PickInstance n -> Int
 pickSolution = head . M.keys . M.filter fst . nets
 
 renderPick
-  :: (MonadCache m, MonadDiagrams m, MonadGraphviz m, MonadThrow m, Net p n)
-  => String
+  :: (
+    Data (n String),
+    Data (p n String),
+    MonadCache m,
+    MonadDiagrams m,
+    MonadGraphviz m,
+    MonadThrow m,
+    Net p n,
+    Typeable n,
+    Typeable p
+    )
+  => FilePath
   -> PickInstance (p n String)
   -> m (Map Int (Bool, String))
 renderPick path config =

--- a/src/Modelling/PetriNet/Types.hs
+++ b/src/Modelling/PetriNet/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# Language DeriveTraversable #-}
 {-# Language DuplicateRecordFields #-}
@@ -124,6 +125,7 @@ import Control.Monad.Catch              (Exception, MonadThrow (throwM))
 import Control.Monad.Random             (MonadRandom, RandT, RandomGen)
 import Control.Monad.Trans              (MonadTrans(lift))
 import Data.Bimap                       (Bimap)
+import Data.Data                        (Data)
 import Data.GraphViz.Attributes.Complete (GraphvizCommand (..))
 import Data.Map.Lazy                    (Map)
 import Data.Maybe                       (fromMaybe)
@@ -287,7 +289,7 @@ data Node a =
   flowIn  :: Map a Int,
   flowOut :: Map a Int
   }
-  deriving (Eq, Generic, Read, Show)
+  deriving (Data, Eq, Generic, Read, Show)
 
 instance PetriNode Node where
   initialTokens PlaceNode {initial} = initial
@@ -318,7 +320,7 @@ data SimpleNode a =
   SimpleTransition {
   flowOut           :: Map a Int
   }
-  deriving (Eq, Generic, Read, Show)
+  deriving (Data, Eq, Generic, Read, Show)
 
 instance PetriNode SimpleNode where
   initialTokens SimplePlace {initial} = initial
@@ -459,7 +461,7 @@ The 'PetriLike' graph is a valid Petri net only if
 newtype PetriLike n a = PetriLike {
   -- | the 'Map' of all nodes the Petri net like graph is made of
   allNodes :: Map a (n a)
-  } deriving (Eq, Generic, Read, Show)
+  } deriving (Data, Eq, Generic, Read, Show)
 
 instance Net PetriLike Node where
   emptyNet = PetriLike M.empty


### PR DESCRIPTION
@jvoigtlaender I wanted to send this to discussion before incorporating it. The basic idea is, that different representations of `PetriLike` graphs are separated by name (as their hashes would never overlap useful anyway). But this change requires additional `Data` and `Typeable` constraints in several places (the underlying instances are then used to add parts to the file name). But maybe this is too overcautious?