### PR TITLE
refactor out components to generate a petri simulation

### DIFF
--- a/example/src/Modelling/PetriNet/PetriReach/Config.hs
+++ b/example/src/Modelling/PetriNet/PetriReach/Config.hs
@@ -2,7 +2,7 @@
 
 module Modelling.PetriNet.PetriReach.Config where
 
-import Modelling.PetriNet.Reach.Reach   (ReachConfig(..))
+import Modelling.PetriNet.Reach.Reach   (ReachConfig(..), NetGoalConfig(..))
 import Modelling.PetriNet.Reach.Type    (Capacity(..))
 import Data.GraphViz.Commands           (GraphvizCommand(..))
 
@@ -11,14 +11,16 @@ points: 0.2
 -}
 task2023_27 :: ReachConfig
 task2023_27 = ReachConfig {
-  numPlaces = 4,
-  numTransitions = 4,
-  capacity = Unbounded,
-  drawCommands = [Circo],
-  maxTransitionLength = 8,
-  minTransitionLength = 8,
-  postconditionsRange = (2, Just 3),
-  preconditionsRange = (2, Just 2),
+  netGoalConf  = NetGoalConfig {
+    numPlaces = 4,
+    numTransitions = 4,
+    capacity = Unbounded,
+    drawCommands = [Circo],
+    maxTransitionLength = 8,
+    minTransitionLength = 8,
+    postconditionsRange = (2, Just 3),
+    preconditionsRange = (2, Just 2)
+    },
   printSolution = True,
   rejectLongerThan = Nothing,
   showLengthHint = True,
@@ -31,14 +33,16 @@ points: 0.25
 -}
 task2023_28 :: ReachConfig
 task2023_28 = ReachConfig {
-  numPlaces = 6,
-  numTransitions = 6,
-  capacity = Unbounded,
-  drawCommands = [Circo],
-  maxTransitionLength = 12,
-  minTransitionLength = 12,
-  postconditionsRange = (2, Just 3),
-  preconditionsRange = (2, Just 2),
+  netGoalConf = NetGoalConfig {
+    numPlaces = 6,
+    numTransitions = 6,
+    capacity = Unbounded,
+    drawCommands = [Circo],
+    maxTransitionLength = 12,
+    minTransitionLength = 12,
+    postconditionsRange = (2, Just 3),
+    preconditionsRange = (2, Just 2)
+    },
   printSolution = True,
   rejectLongerThan = Nothing,
   showLengthHint = True,
@@ -63,14 +67,16 @@ points: 0.08
 -}
 task2024_60 :: ReachConfig
 task2024_60 = ReachConfig {
-  numPlaces = 4,
-  numTransitions = 4,
-  capacity = Unbounded,
-  drawCommands = [Circo],
-  maxTransitionLength = 8,
-  minTransitionLength = 8,
-  postconditionsRange = (2, Just 3),
-  preconditionsRange = (2, Just 2),
+  netGoalConf = NetGoalConfig {
+    numPlaces = 4,
+    numTransitions = 4,
+    capacity = Unbounded,
+    drawCommands = [Circo],
+    maxTransitionLength = 8,
+    minTransitionLength = 8,
+    postconditionsRange = (2, Just 3),
+    preconditionsRange = (2, Just 2)
+    },
   printSolution = True,
   rejectLongerThan = Just 8,
   showLengthHint = True,

--- a/example/src/Modelling/PetriNet/PetriReach/Config.hs
+++ b/example/src/Modelling/PetriNet/PetriReach/Config.hs
@@ -11,7 +11,7 @@ points: 0.2
 -}
 task2023_27 :: ReachConfig
 task2023_27 = ReachConfig {
-  netGoalConf  = NetGoalConfig {
+  netGoalConfig  = NetGoalConfig {
     numPlaces = 4,
     numTransitions = 4,
     capacity = Unbounded,
@@ -33,7 +33,7 @@ points: 0.25
 -}
 task2023_28 :: ReachConfig
 task2023_28 = ReachConfig {
-  netGoalConf = NetGoalConfig {
+  netGoalConfig = NetGoalConfig {
     numPlaces = 6,
     numTransitions = 6,
     capacity = Unbounded,
@@ -67,7 +67,7 @@ points: 0.08
 -}
 task2024_60 :: ReachConfig
 task2024_60 = ReachConfig {
-  netGoalConf = NetGoalConfig {
+  netGoalConfig = NetGoalConfig {
     numPlaces = 4,
     numTransitions = 4,
     capacity = Unbounded,

--- a/example/src/Modelling/PetriNet/PetriReach/Instance.hs
+++ b/example/src/Modelling/PetriNet/PetriReach/Instance.hs
@@ -5,42 +5,44 @@ module Modelling.PetriNet.PetriReach.Instance where
 import qualified Data.Map                         as M (fromList)
 import qualified Data.Set                         as S (fromList)
 
-import Modelling.PetriNet.Reach.Reach   (ReachInstance (..))
+import Modelling.PetriNet.Reach.Reach   (ReachInstance (..), NetGoalInstance(..))
 import Modelling.PetriNet.Reach.Type    (Capacity (..), Net (..), State (..))
 import Data.GraphViz                    (GraphvizCommand (Circo))
 
 task5 :: ReachInstance String String
 task5 = ReachInstance {
-  drawUsing = Circo,
-  goal = State {
-    unState = M.fromList
-      [("s1", 1), ("s2", 1), ("s3", 1), ("s4", 0), ("s5", 4), ("s6", 0)]
+  netGoal = NetGoalInstance {
+    drawUsing = Circo,
+    goal = State {
+      unState = M.fromList
+        [("s1", 1), ("s2", 1), ("s3", 1), ("s4", 0), ("s5", 4), ("s6", 0)]
+      },
+    petriNet = Net {
+      places = S.fromList ["s1", "s2", "s3", "s4", "s5", "s6"],
+      transitions = S.fromList ["t1", "t2", "t3", "t4", "t5", "t6"],
+      connections = [
+        (["s1", "s5"], "t1", ["s6", "s2", "s1"]),
+        (["s3", "s1"], "t2", ["s5", "s6"]),
+        (["s4", "s5"], "t3", ["s3", "s5"]),
+        (["s6", "s4"], "t4", ["s5", "s4"]),
+        (["s2", "s5"], "t5", ["s4", "s2", "s1"]),
+        (["s2", "s3"], "t6", ["s2", "s3"])
+       ],
+      capacity = Unbounded,
+      start = State {
+        unState = M.fromList [
+          ("s1", 1),
+          ("s2", 1),
+          ("s3", 1),
+          ("s4", 0),
+          ("s5", 1),
+          ("s6", 0)
+         ]
+        }
+      }
     },
   minLength = 12,
   noLongerThan = Nothing,
-  petriNet = Net {
-    places = S.fromList ["s1", "s2", "s3", "s4", "s5", "s6"],
-    transitions = S.fromList ["t1", "t2", "t3", "t4", "t5", "t6"],
-    connections = [
-      (["s1", "s5"], "t1", ["s6", "s2", "s1"]),
-      (["s3", "s1"], "t2", ["s5", "s6"]),
-      (["s4", "s5"], "t3", ["s3", "s5"]),
-      (["s6", "s4"], "t4", ["s5", "s4"]),
-      (["s2", "s5"], "t5", ["s4", "s2", "s1"]),
-      (["s2", "s3"], "t6", ["s2", "s3"])
-     ],
-    capacity = Unbounded,
-    start = State {
-      unState = M.fromList [
-        ("s1", 1),
-        ("s2", 1),
-        ("s3", 1),
-        ("s4", 0),
-        ("s5", 1),
-        ("s6", 0)
-       ]
-      }
-    },
   showGoalNet = True,
   showSolution = True,
   withLengthHint = Just 12,

--- a/example/src/Modelling/PetriNet/PetriReach/Instance.hs
+++ b/example/src/Modelling/PetriNet/PetriReach/Instance.hs
@@ -5,13 +5,13 @@ module Modelling.PetriNet.PetriReach.Instance where
 import qualified Data.Map                         as M (fromList)
 import qualified Data.Set                         as S (fromList)
 
-import Modelling.PetriNet.Reach.Reach   (ReachInstance (..), NetGoalInstance(..))
+import Modelling.PetriNet.Reach.Reach   (ReachInstance (..), NetGoal(..))
 import Modelling.PetriNet.Reach.Type    (Capacity (..), Net (..), State (..))
 import Data.GraphViz                    (GraphvizCommand (Circo))
 
 task5 :: ReachInstance String String
 task5 = ReachInstance {
-  netGoal = NetGoalInstance {
+  netGoal = NetGoal {
     drawUsing = Circo,
     goal = State {
       unState = M.fromList

--- a/src/Modelling/PetriNet/Reach/Reach.hs
+++ b/src/Modelling/PetriNet/Reach/Reach.hs
@@ -291,7 +291,7 @@ isNoLonger maybeMaxLength ts =
         ]
 
 data ReachInstance s t = ReachInstance {
-  netGoal           :: NetGoalInstance s t,
+  netGoal           :: NetGoal s t,
   minLength         :: Int,
   noLongerThan      :: Maybe Int,
   showGoalNet       :: Bool,
@@ -300,7 +300,7 @@ data ReachInstance s t = ReachInstance {
   withMinLengthHint :: Maybe Int
   } deriving (Generic, Read, Show, Typeable, Data)
 
-data NetGoalInstance s t = NetGoalInstance {
+data NetGoal s t = NetGoal {
   drawUsing         :: GraphvizCommand,
   petriNet          :: Net s t,
   goal              :: State s
@@ -313,7 +313,7 @@ bimapReachInstance
   -> ReachInstance s t
   -> ReachInstance a b
 bimapReachInstance f g ReachInstance {..} = ReachInstance {
-    netGoal           = bimapNetGoalInstance f g netGoal,
+    netGoal           = bimapNetGoal f g netGoal,
     minLength         = minLength,
     noLongerThan      = noLongerThan,
     showGoalNet       = showGoalNet,
@@ -322,13 +322,13 @@ bimapReachInstance f g ReachInstance {..} = ReachInstance {
     withMinLengthHint = withMinLengthHint
     }
 
-bimapNetGoalInstance
+bimapNetGoal
   :: (Ord a, Ord b)
   => (s -> a)
   -> (t -> b)
-  -> NetGoalInstance s t
-  -> NetGoalInstance a b
-bimapNetGoalInstance f g NetGoalInstance {..} = NetGoalInstance {
+  -> NetGoal s t
+  -> NetGoal a b
+bimapNetGoal f g NetGoal {..} = NetGoal {
     drawUsing = drawUsing,
     goal      = mapState f goal,
     petriNet  = bimapNet f g petriNet
@@ -339,13 +339,13 @@ toShowReachInstance
   -> ReachInstance ShowPlace ShowTransition
 toShowReachInstance = bimapReachInstance ShowPlace ShowTransition
 
-toShowNetGoalInstance
-  :: NetGoalInstance Place Transition
-  -> NetGoalInstance ShowPlace ShowTransition
-toShowNetGoalInstance = bimapNetGoalInstance ShowPlace ShowTransition
+toShowNetGoal
+  :: NetGoal Place Transition
+  -> NetGoal ShowPlace ShowTransition
+toShowNetGoal = bimapNetGoal ShowPlace ShowTransition
 
 data ReachConfig = ReachConfig {
-  netGoalConf         :: NetGoalConfig,
+  netGoalConfig       :: NetGoalConfig,
   printSolution       :: Bool,
   rejectLongerThan    :: Maybe Int,
   showLengthHint      :: Bool,
@@ -368,7 +368,7 @@ data NetGoalConfig = NetGoalConfig {
 
 defaultReachConfig :: ReachConfig
 defaultReachConfig = ReachConfig {
-  netGoalConf = NetGoalConfig {
+  netGoalConfig = NetGoalConfig {
     numPlaces           = 4,
     numTransitions      = 4,
     Modelling.PetriNet.Reach.Reach.capacity = Unbounded,
@@ -387,7 +387,7 @@ defaultReachConfig = ReachConfig {
 
 defaultReachInstance :: ReachInstance Place Transition
 defaultReachInstance = ReachInstance {
-  netGoal = NetGoalInstance {
+  netGoal = NetGoal {
     drawUsing         = Circo,
     petriNet          = fst example,
     goal              = snd example
@@ -404,7 +404,7 @@ generateNetGoal
   :: (MonadCatch m, MonadDiagrams m, MonadGraphviz m)
   => NetGoalConfig
   -> Int
-  -> m (NetGoalInstance Place Transition)
+  -> m (NetGoal Place Transition)
 generateNetGoal conf seed = do
   let ps = [Place 1 .. Place (numPlaces conf)]
       tries = forM [1 :: Int .. 1000] $ const $ do
@@ -431,7 +431,7 @@ generateNetGoal conf seed = do
 
   ((petri, state), cmd) <- eval out
 
-  return $ NetGoalInstance {
+  return $ NetGoal {
     drawUsing   = cmd,
     goal        = state,
     petriNet    = petri
@@ -450,15 +450,15 @@ generateReach
   -> Int
   -> m (ReachInstance Place Transition)
 generateReach conf seed = do
-  netGoal <- generateNetGoal (netGoalConf conf) seed
+  netGoal <- generateNetGoal (netGoalConfig conf) seed
   pure $ ReachInstance {
     netGoal           = netGoal,
-    minLength         = minTransitionLength (netGoalConf conf),
+    minLength         = minTransitionLength (netGoalConfig conf),
     noLongerThan      = rejectLongerThan conf,
     showGoalNet       = showTargetNet conf,
     showSolution      = printSolution conf,
     withLengthHint    =
-      if showLengthHint conf then Just $ maxTransitionLength (netGoalConf conf) else Nothing,
+      if showLengthHint conf then Just $ maxTransitionLength (netGoalConfig conf) else Nothing,
     withMinLengthHint =
-      if showMinLengthHint conf then Just $ minTransitionLength (netGoalConf conf) else Nothing
+      if showMinLengthHint conf then Just $ minTransitionLength (netGoalConfig conf) else Nothing
     }

--- a/src/Modelling/PetriNet/Reach/Reach.hs
+++ b/src/Modelling/PetriNet/Reach/Reach.hs
@@ -244,10 +244,13 @@ reachEvaluation path reach ts =
       | showSolution reach = Just $ show $ TransitionsList $ reachSolution reach
       | otherwise = Nothing
 
+netGoalSolution :: Ord s => NetGoal s t -> [t]
+netGoalSolution netGoal = reverse $ snd $ head $ concatMap
+  (filter $ (== goal netGoal) . fst)
+  $ levels' $ petriNet netGoal
+
 reachSolution :: Ord s => ReachInstance s t -> [t]
-reachSolution inst = reverse $ snd $ head $ concatMap
-  (filter $ (== goal (netGoal inst)) . fst)
-  $ levels' $ petriNet (netGoal inst)
+reachSolution inst = netGoalSolution (netGoal inst)
 
 assertReachPoints
   :: OutputCapable m

--- a/src/Modelling/PetriNet/Reach/Reach.hs
+++ b/src/Modelling/PetriNet/Reach/Reach.hs
@@ -431,7 +431,7 @@ generateNetGoal conf seed = do
 
   ((petri, state), cmd) <- eval out
 
-  return $ NetGoal {
+  pure $ NetGoal {
     drawUsing   = cmd,
     goal        = state,
     petriNet    = petri

--- a/src/Modelling/PetriNet/Reach/Reach.hs
+++ b/src/Modelling/PetriNet/Reach/Reach.hs
@@ -405,16 +405,16 @@ generateNetGoal
   => NetGoalConfig
   -> Int
   -> m (NetGoal Place Transition)
-generateNetGoal conf seed = do
-  let ps = [Place 1 .. Place (numPlaces conf)]
+generateNetGoal NetGoalConfig {..} seed = do
+  let ps = [Place 1 .. Place numPlaces]
       tries = forM [1 :: Int .. 1000] $ const $ do
         n <- netLimits vLow vHigh nLow nHigh
             ps
             ts
-            (Modelling.PetriNet.Reach.Reach.capacity conf)
+            capacity
         return $ do
           (l,zs) <-
-            take (maxTransitionLength conf + 1) $ zip [0 :: Int ..] $ levels n
+            take (maxTransitionLength + 1) $ zip [0 :: Int ..] $ levels n
           z' <- zs
           let d = sum $ do
                 p <- ps
@@ -423,10 +423,10 @@ generateNetGoal conf seed = do
       out = do
         xs <- tries
         let ((l, _), pn) = minimumBy (comparing fst) $ concat xs
-        if negate l >= minTransitionLength conf
+        if negate l >= minTransitionLength
           then do
             maybeM out (pure . (pn,))
-            $ findM (Monad.lift . isPetriDrawable (fst pn)) $ drawCommands conf
+            $ findM (Monad.lift . isPetriDrawable (fst pn)) drawCommands
           else out
 
   ((petri, state), cmd) <- eval out
@@ -438,10 +438,10 @@ generateNetGoal conf seed = do
     }
 
   where
-    fixMaximum = second (min (numPlaces conf) . fromMaybe maxBound)
-    (vLow, vHigh) = fixMaximum $ preconditionsRange conf
-    (nLow, nHigh) = fixMaximum $ postconditionsRange conf
-    ts = [Transition 1 .. Transition (numTransitions conf)]
+    fixMaximum = second (min numPlaces . fromMaybe maxBound)
+    (vLow, vHigh) = fixMaximum preconditionsRange
+    (nLow, nHigh) = fixMaximum postconditionsRange
+    ts = [Transition 1 .. Transition numTransitions]
     eval f = evalRandT f $ mkStdGen seed
 
 generateReach
@@ -449,16 +449,16 @@ generateReach
   => ReachConfig
   -> Int
   -> m (ReachInstance Place Transition)
-generateReach conf seed = do
-  netGoal <- generateNetGoal (netGoalConfig conf) seed
+generateReach ReachConfig {..} seed = do
+  netGoal <- generateNetGoal netGoalConfig seed
   pure $ ReachInstance {
     netGoal           = netGoal,
-    minLength         = minTransitionLength (netGoalConfig conf),
-    noLongerThan      = rejectLongerThan conf,
-    showGoalNet       = showTargetNet conf,
-    showSolution      = printSolution conf,
+    minLength         = minTransitionLength netGoalConfig,
+    noLongerThan      = rejectLongerThan,
+    showGoalNet       = showTargetNet,
+    showSolution      = printSolution,
     withLengthHint    =
-      if showLengthHint conf then Just $ maxTransitionLength (netGoalConfig conf) else Nothing,
+      if showLengthHint then Just $ maxTransitionLength netGoalConfig else Nothing,
     withMinLengthHint =
-      if showMinLengthHint conf then Just $ minTransitionLength (netGoalConfig conf) else Nothing
+      if showMinLengthHint then Just $ minTransitionLength netGoalConfig else Nothing
     }

--- a/src/Modelling/PetriNet/Reach/Reach.hs
+++ b/src/Modelling/PetriNet/Reach/Reach.hs
@@ -88,9 +88,9 @@ verifyReach :: (Ord a, Ord t, OutputCapable m, Show a, Show t)
   => ReachInstance a t
   -> LangM m
 verifyReach inst = do
-  let n = petriNet inst
+  let n = petriNet (netGoal inst)
   validate Default n
-  validate Default $ n { start = goal inst }
+  validate Default $ n { start = goal (netGoal inst) }
   pure ()
 
 reachTask
@@ -111,10 +111,10 @@ reachTask
 reachTask path inst = do
   if showGoalNet inst
     then (,True) . Left
-    <$> lift (drawToFile True path (drawUsing inst) (n { start = goal inst }))
-    else pure (Right $ show $ goal inst, False)
+    <$> lift (drawToFile True path (drawUsing (netGoal inst)) (n { start = goal (netGoal inst) }))
+    else pure (Right $ show $ goal (netGoal inst), False)
   $>>= \(g, withoutPlaceNames) ->
-    lift (drawToFile withoutPlaceNames path (drawUsing inst) n)
+    lift (drawToFile withoutPlaceNames path (drawUsing (netGoal inst)) n)
   $>>= \img -> reportReachFor
     img
     (noLongerThan inst)
@@ -122,7 +122,7 @@ reachTask path inst = do
     (withMinLengthHint inst)
     (Just g)
   where
-    n = petriNet inst
+    n = petriNet (netGoal inst)
 
 reportReachFor
   :: OutputCapable m
@@ -183,7 +183,7 @@ reportReachFor img noLonger lengthHint minLengthHint maybeGoal = do
   pure ()
 
 reachInitial :: ReachInstance s Transition -> TransitionsList
-reachInitial = TransitionsList . reverse . S.toList . transitions . petriNet
+reachInitial = TransitionsList . reverse . S.toList . transitions . petriNet . netGoal
 
 reachSyntax
   :: OutputCapable m
@@ -191,7 +191,7 @@ reachSyntax
   -> [Transition]
   -> LangM m
 reachSyntax inst ts =
-  do transitionsValid (petriNet inst) ts
+  do transitionsValid (petriNet (netGoal inst)) ts
      isNoLonger (noLongerThan inst) ts
      pure ()
 
@@ -224,30 +224,30 @@ reachEvaluation path reach ts =
        german "Startmarkierung:"
      indent $ text $ show (start n)
      pure ()
-  $>> executes path (drawUsing reachInstance) n (map ShowTransition ts)
+  $>> executes path (drawUsing (netGoal reachInstance)) n (map ShowTransition ts)
   $>>= \eitherOutcome -> whenRight eitherOutcome (\outcome ->
-    yesNo (outcome == goal reachInstance) $ translate $ do
+    yesNo (outcome == goal (netGoal reachInstance)) $ translate $ do
       english "Reached target marking?"
       german "Zielmarkierung erreicht?"
     )
   $>> assertReachPoints
     aSolution
-    ((==) . goal)
+    ((==) . goal . netGoal)
     minLength
     reachInstance
     ts
     eitherOutcome
   where
     reachInstance = toShowReachInstance reach
-    n = petriNet reachInstance
+    n = petriNet (netGoal reachInstance)
     aSolution
       | showSolution reach = Just $ show $ TransitionsList $ reachSolution reach
       | otherwise = Nothing
 
 reachSolution :: Ord s => ReachInstance s t -> [t]
 reachSolution inst = reverse $ snd $ head $ concatMap
-  (filter $ (== goal inst) . fst)
-  $ levels' $ petriNet inst
+  (filter $ (== goal (netGoal inst)) . fst)
+  $ levels' $ petriNet (netGoal inst)
 
 assertReachPoints
   :: OutputCapable m
@@ -291,17 +291,20 @@ isNoLonger maybeMaxLength ts =
         ]
 
 data ReachInstance s t = ReachInstance {
-  drawUsing         :: GraphvizCommand,
-  goal              :: State s,
+  netGoal           :: NetGoalInstance s t,
   minLength         :: Int,
   noLongerThan      :: Maybe Int,
-  petriNet          :: Net s t,
   showGoalNet       :: Bool,
   showSolution      :: Bool,
   withLengthHint    :: Maybe Int,
   withMinLengthHint :: Maybe Int
   } deriving (Generic, Read, Show, Typeable, Data)
 
+data NetGoalInstance s t = NetGoalInstance {
+  drawUsing         :: GraphvizCommand,
+  petriNet          :: Net s t,
+  goal              :: State s
+  } deriving (Generic, Read, Show, Typeable, Data)
 
 bimapReachInstance
   :: (Ord a, Ord b)
@@ -310,15 +313,25 @@ bimapReachInstance
   -> ReachInstance s t
   -> ReachInstance a b
 bimapReachInstance f g ReachInstance {..} = ReachInstance {
-    drawUsing         = drawUsing,
-    goal              = mapState f goal,
+    netGoal           = bimapNetGoalInstance f g netGoal,
     minLength         = minLength,
     noLongerThan      = noLongerThan,
-    petriNet          = bimapNet f g petriNet,
     showGoalNet       = showGoalNet,
     showSolution      = showSolution,
     withLengthHint    = withLengthHint,
     withMinLengthHint = withMinLengthHint
+    }
+
+bimapNetGoalInstance
+  :: (Ord a, Ord b)
+  => (s -> a)
+  -> (t -> b)
+  -> NetGoalInstance s t
+  -> NetGoalInstance a b
+bimapNetGoalInstance f g NetGoalInstance {..} = NetGoalInstance {
+    drawUsing = drawUsing,
+    goal      = mapState f goal,
+    petriNet  = bimapNet f g petriNet
     }
 
 toShowReachInstance
@@ -326,15 +339,13 @@ toShowReachInstance
   -> ReachInstance ShowPlace ShowTransition
 toShowReachInstance = bimapReachInstance ShowPlace ShowTransition
 
+toShowNetGoalInstance
+  :: NetGoalInstance Place Transition
+  -> NetGoalInstance ShowPlace ShowTransition
+toShowNetGoalInstance = bimapNetGoalInstance ShowPlace ShowTransition
+
 data ReachConfig = ReachConfig {
-  numPlaces :: Int,
-  numTransitions :: Int,
-  capacity :: Capacity Place,
-  drawCommands        :: [GraphvizCommand],
-  maxTransitionLength :: Int,
-  minTransitionLength :: Int,
-  postconditionsRange :: (Int, Maybe Int),
-  preconditionsRange  :: (Int, Maybe Int),
+  netGoalConf         :: NetGoalConfig,
   printSolution       :: Bool,
   rejectLongerThan    :: Maybe Int,
   showLengthHint      :: Bool,
@@ -343,16 +354,30 @@ data ReachConfig = ReachConfig {
   }
   deriving (Generic, Read, Show, Typeable)
 
+data NetGoalConfig = NetGoalConfig {
+  numPlaces :: Int,
+  numTransitions :: Int,
+  capacity :: Capacity Place,
+  drawCommands        :: [GraphvizCommand],
+  maxTransitionLength :: Int,
+  minTransitionLength :: Int,
+  postconditionsRange :: (Int, Maybe Int),
+  preconditionsRange  :: (Int, Maybe Int)
+  }
+  deriving (Generic, Read, Show, Typeable)
+
 defaultReachConfig :: ReachConfig
 defaultReachConfig = ReachConfig {
-  numPlaces = 4,
-  numTransitions = 4,
-  Modelling.PetriNet.Reach.Reach.capacity = Unbounded,
-  drawCommands        = [Dot, Neato, TwoPi, Circo, Fdp, Sfdp, Osage, Patchwork],
-  maxTransitionLength = 8,
-  minTransitionLength = 6,
-  postconditionsRange = (0, Nothing),
-  preconditionsRange  = (0, Nothing),
+  netGoalConf = NetGoalConfig {
+    numPlaces           = 4,
+    numTransitions      = 4,
+    Modelling.PetriNet.Reach.Reach.capacity = Unbounded,
+    drawCommands        = [Dot, Neato, TwoPi, Circo, Fdp, Sfdp, Osage, Patchwork],
+    maxTransitionLength = 8,
+    minTransitionLength = 6,
+    postconditionsRange = (0, Nothing),
+    preconditionsRange  = (0, Nothing)
+    },
   printSolution       = False,
   rejectLongerThan    = Nothing,
   showLengthHint      = True,
@@ -362,23 +387,25 @@ defaultReachConfig = ReachConfig {
 
 defaultReachInstance :: ReachInstance Place Transition
 defaultReachInstance = ReachInstance {
-  drawUsing         = Circo,
-  goal              = snd example,
+  netGoal = NetGoalInstance {
+    drawUsing         = Circo,
+    petriNet          = fst example,
+    goal              = snd example
+    },
   minLength         = 12,
   noLongerThan      = Nothing,
-  petriNet          = fst example,
   showGoalNet       = True,
   showSolution      = False,
   withLengthHint    = Just 12,
   withMinLengthHint = Nothing
 }
 
-generateReach
+generateNetGoal
   :: (MonadCatch m, MonadDiagrams m, MonadGraphviz m)
-  => ReachConfig
+  => NetGoalConfig
   -> Int
-  -> m (ReachInstance Place Transition)
-generateReach conf seed = do
+  -> m (NetGoalInstance Place Transition)
+generateNetGoal conf seed = do
   let ps = [Place 1 .. Place (numPlaces conf)]
       tries = forM [1 :: Int .. 1000] $ const $ do
         n <- netLimits vLow vHigh nLow nHigh
@@ -401,23 +428,37 @@ generateReach conf seed = do
             maybeM out (pure . (pn,))
             $ findM (Monad.lift . isPetriDrawable (fst pn)) $ drawCommands conf
           else out
+
   ((petri, state), cmd) <- eval out
-  pure $ ReachInstance {
-    drawUsing         = cmd,
-    goal              = state,
-    minLength         = minTransitionLength conf,
-    noLongerThan      = rejectLongerThan conf,
-    petriNet          = petri,
-    showGoalNet       = showTargetNet conf,
-    showSolution      = printSolution conf,
-    withLengthHint    =
-      if showLengthHint conf then Just $ maxTransitionLength conf else Nothing,
-    withMinLengthHint =
-      if showMinLengthHint conf then Just $ minTransitionLength conf else Nothing
+
+  return $ NetGoalInstance {
+    drawUsing   = cmd,
+    goal        = state,
+    petriNet    = petri
     }
+
   where
     fixMaximum = second (min (numPlaces conf) . fromMaybe maxBound)
     (vLow, vHigh) = fixMaximum $ preconditionsRange conf
     (nLow, nHigh) = fixMaximum $ postconditionsRange conf
     ts = [Transition 1 .. Transition (numTransitions conf)]
     eval f = evalRandT f $ mkStdGen seed
+
+generateReach
+  :: (MonadCatch m, MonadDiagrams m, MonadGraphviz m)
+  => ReachConfig
+  -> Int
+  -> m (ReachInstance Place Transition)
+generateReach conf seed = do
+  netGoal <- generateNetGoal (netGoalConf conf) seed
+  pure $ ReachInstance {
+    netGoal           = netGoal,
+    minLength         = minTransitionLength (netGoalConf conf),
+    noLongerThan      = rejectLongerThan conf,
+    showGoalNet       = showTargetNet conf,
+    showSolution      = printSolution conf,
+    withLengthHint    =
+      if showLengthHint conf then Just $ maxTransitionLength (netGoalConf conf) else Nothing,
+    withMinLengthHint =
+      if showMinLengthHint conf then Just $ minTransitionLength (netGoalConf conf) else Nothing
+    }

--- a/test/Modelling/PetriNet/Reach/ReachSpec.hs
+++ b/test/Modelling/PetriNet/Reach/ReachSpec.hs
@@ -8,7 +8,7 @@ import Modelling.PetriNet.Reach.Reach (
   ReachConfig (..),
   NetGoalConfig (..),
   ReachInstance (..),
-  NetGoalInstance (..),
+  NetGoal (..),
   defaultReachConfig,
   generateReach,
   )
@@ -31,12 +31,12 @@ spec =
     it "abides minTransitionLength" $
       property $ \seed -> do
         let config = defaultReachConfig {
-              netGoalConf = (netGoalConf defaultReachConfig) {
+              netGoalConfig = (netGoalConfig defaultReachConfig) {
                 maxTransitionLength = 6,
                 minTransitionLength = 6
                 }
               }
-            minL = minTransitionLength (netGoalConf config)
+            minL = minTransitionLength (netGoalConfig config)
         inst <- generateReach config seed
         let net = petriNet (netGoal inst)
             s = goal (netGoal inst)

--- a/test/Modelling/PetriNet/Reach/ReachSpec.hs
+++ b/test/Modelling/PetriNet/Reach/ReachSpec.hs
@@ -6,7 +6,9 @@ import Capabilities.Diagrams.IO         ()
 import Capabilities.Graphviz.IO         ()
 import Modelling.PetriNet.Reach.Reach (
   ReachConfig (..),
+  NetGoalConfig (..),
   ReachInstance (..),
+  NetGoalInstance (..),
   defaultReachConfig,
   generateReach,
   )
@@ -29,13 +31,15 @@ spec =
     it "abides minTransitionLength" $
       property $ \seed -> do
         let config = defaultReachConfig {
-              maxTransitionLength = 6,
-              minTransitionLength = 6
+              netGoalConf = (netGoalConf defaultReachConfig) {
+                maxTransitionLength = 6,
+                minTransitionLength = 6
+                }
               }
-            minL = minTransitionLength config
+            minL = minTransitionLength (netGoalConf config)
         inst <- generateReach config seed
-        let net = petriNet inst
-            s = goal inst
+        let net = petriNet (netGoal inst)
+            s = goal (netGoal inst)
             ts = transitions net
         net `shouldSatisfy` hasMinTransitionLength (s ==) ts minL
 


### PR DESCRIPTION
as discussed in https://github.com/fmidue/ba-pei-ching/pull/3#discussion_r2203461996

Refactors out components that are commonly used to generate a "simulation" i.e. an initial net + transitions + the final state after transitions