### PR TITLE
incorporate filewrite|render split in capabilities

### DIFF
--- a/app/check-cds.hs
+++ b/app/check-cds.hs
@@ -1,10 +1,12 @@
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 module Main where
 
+import qualified Data.ByteString.Char8            as BS (writeFile)
 import qualified Language.Alloy.Call              as Alloy (getInstances)
 
 import Capabilities.Diagrams.IO         ()
 import Capabilities.Graphviz.IO         ()
+import Capabilities.WriteFile.IO        ()
 import Modelling.CdOd.CD2Alloy.Transform (
   LinguisticReuse (None),
   combineParts,
@@ -235,8 +237,10 @@ drawCdAndOdsFor is c cds cmd = do
       Back
       True
       (c ++ '-' : shorten cmd ++ "-od" ++ show i ++ ".svg")
-    drawCd' cd i =
-      drawCd defaultCdDrawSettings mempty cd (c ++ "-cd" ++ show i ++ ".svg")
+    drawCd' cd i = do
+      renderedCd <- drawCd defaultCdDrawSettings mempty cd
+      BS.writeFile (c ++ "-cd" ++ show i ++ ".svg") renderedCd
+      pure $ c ++ "-cd" ++ show i ++ ".svg"
     maxThreeObjects = maxFiveObjects { objectLimits = (1, 3) }
     getParts relationshipNames = zipWith (cdToAlloy relationshipNames) cds [0..]
     cdToAlloy relationshipNames cd i = transform

--- a/app/enterASTaskDemo.hs
+++ b/app/enterASTaskDemo.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Capabilities.Alloy.IO            ()
 import Capabilities.PlantUml.IO         ()
+import Capabilities.WriteFile.IO        ()
 import Modelling.ActivityDiagram.EnterAS (
   defaultEnterASConfig,
   enterAS,

--- a/app/findAuxiliaryPetriNodesTaskDemo.hs
+++ b/app/findAuxiliaryPetriNodesTaskDemo.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Capabilities.Alloy.IO            ()
 import Capabilities.PlantUml.IO         ()
+import Capabilities.WriteFile.IO         ()
 import Modelling.ActivityDiagram.FindAuxiliaryPetriNodes (
   defaultFindAuxiliaryPetriNodesConfig,
   findAuxiliaryPetriNodes,

--- a/app/matchAdTaskDemo.hs
+++ b/app/matchAdTaskDemo.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Capabilities.Alloy.IO            ()
 import Capabilities.PlantUml.IO         ()
+import Capabilities.WriteFile.IO        ()
 import Modelling.ActivityDiagram.MatchAd (
   defaultMatchAdConfig,
   matchAd,

--- a/app/matchPetriTaskDemo.hs
+++ b/app/matchPetriTaskDemo.hs
@@ -5,6 +5,7 @@ import Capabilities.Cache.IO            ()
 import Capabilities.Diagrams.IO         ()
 import Capabilities.Graphviz.IO         ()
 import Capabilities.PlantUml.IO         ()
+import Capabilities.WriteFile.IO        ()
 import Modelling.ActivityDiagram.MatchPetri (
   defaultMatchPetriConfig,
   matchPetri,

--- a/app/selectASTaskDemo.hs
+++ b/app/selectASTaskDemo.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Capabilities.Alloy.IO            ()
 import Capabilities.PlantUml.IO         ()
+import Capabilities.WriteFile.IO        ()
 import Modelling.ActivityDiagram.SelectAS (
   defaultSelectASConfig,
   selectAS,

--- a/app/selectPetriTaskDemo.hs
+++ b/app/selectPetriTaskDemo.hs
@@ -5,6 +5,7 @@ import Capabilities.Cache.IO            ()
 import Capabilities.Diagrams.IO         ()
 import Capabilities.Graphviz.IO         ()
 import Capabilities.PlantUml.IO         ()
+import Capabilities.WriteFile.IO        ()
 import Modelling.ActivityDiagram.SelectPetri (
   defaultSelectPetriConfig,
   selectPetri,

--- a/legacy-app/cd2pic.hs
+++ b/legacy-app/cd2pic.hs
@@ -1,7 +1,10 @@
 module Main (main) where
 
+import qualified Data.ByteString                  as BS (writeFile)
+
 import Capabilities.Diagrams.IO         ()
 import Capabilities.Graphviz.IO         ()
+import Capabilities.WriteFile.IO        ()
 import Modelling.CdOd.Auxiliary.Lexer (lexer)
 import Modelling.CdOd.Auxiliary.Parser (parser)
 import Modelling.CdOd.Output
@@ -32,8 +35,9 @@ run
 run withNames howToMark input file = do
   let tokens = lexer input
   let parsed = parser tokens
-  output <- drawCd drawSettings howToMark (uncurry toCd parsed) file
-  putStrLn $ "Output written to " ++ output
+  output <- drawCd drawSettings howToMark (uncurry toCd parsed)
+  BS.writeFile file output
+  putStrLn $ "Output written to " ++ file
   where
     toCd cs es = fromClassDiagram ClassDiagram {
       classNames = map fst cs,

--- a/legacy-app/instance2pic.hs
+++ b/legacy-app/instance2pic.hs
@@ -3,6 +3,7 @@ import qualified Data.ByteString.Char8            as BS (pack)
 
 import Capabilities.Diagrams.IO         ()
 import Capabilities.Graphviz.IO         ()
+import Capabilities.WriteFile.IO        ()
 import Modelling.CdOd.Output            (drawOdFromInstance)
 
 import Control.Monad (void)

--- a/legacy-app/modelling-tasks-legacy-apps.cabal
+++ b/legacy-app/modelling-tasks-legacy-apps.cabal
@@ -23,6 +23,7 @@ executable cd2alloy
   build-depends:
       array
     , base
+    , bytestring
     , modelling-tasks
     , time
   default-language: Haskell2010
@@ -43,6 +44,7 @@ executable cd2pic
       array
     , autotool-capabilities-io-instances
     , base
+    , bytestring
     , diagrams-lib
     , graphviz
     , modelling-tasks

--- a/legacy-app/package.yaml
+++ b/legacy-app/package.yaml
@@ -14,6 +14,7 @@ ghc-options:
   - -Wwarn=orphans
 dependencies:
   - base
+  - bytestring
 executables:
   cd2alloy:
     main: cd2alloy.hs

--- a/src/Modelling/ActivityDiagram/EnterAS.hs
+++ b/src/Modelling/ActivityDiagram/EnterAS.hs
@@ -24,6 +24,7 @@ module Modelling.ActivityDiagram.EnterAS (
 
 import Capabilities.Alloy               (MonadAlloy, getInstances)
 import Capabilities.PlantUml            (MonadPlantUml)
+import Capabilities.WriteFile           (MonadWriteFile)
 import Modelling.ActivityDiagram.ActionSequences (generateActionSequence, validActionSequence)
 import Modelling.ActivityDiagram.Alloy (
   adConfigToAlloy,
@@ -199,7 +200,7 @@ enterActionSequence ad =
   EnterASSolution {sampleSolution=generateActionSequence ad}
 
 enterASTask
-  :: (MonadPlantUml m, OutputCapable m)
+  :: (MonadPlantUml m, MonadWriteFile m, OutputCapable m)
   => FilePath
   -> EnterASInstance
   -> LangM m

--- a/src/Modelling/ActivityDiagram/FindAuxiliaryPetriNodes.hs
+++ b/src/Modelling/ActivityDiagram/FindAuxiliaryPetriNodes.hs
@@ -35,6 +35,7 @@ import qualified Data.Map as M (
 
 import Capabilities.Alloy               (MonadAlloy, getInstances)
 import Capabilities.PlantUml            (MonadPlantUml)
+import Capabilities.WriteFile           (MonadWriteFile)
 import Modelling.ActivityDiagram.Alloy (
   adConfigToAlloy,
   modulePetriNet,
@@ -215,7 +216,7 @@ findAuxiliaryPetriNodesSolution' petri = FindAuxiliaryPetriNodesSolution {
       $ Petri.nodes petri
 
 findAuxiliaryPetriNodesTask
-  :: (MonadPlantUml m, OutputCapable m)
+  :: (MonadPlantUml m, MonadWriteFile m, OutputCapable m)
   => FilePath
   -> FindAuxiliaryPetriNodesInstance
   -> LangM m

--- a/src/Modelling/ActivityDiagram/MatchAd.hs
+++ b/src/Modelling/ActivityDiagram/MatchAd.hs
@@ -25,6 +25,7 @@ import qualified Data.Map as M (fromList, keys)
 
 import Capabilities.Alloy               (MonadAlloy, getInstances)
 import Capabilities.PlantUml            (MonadPlantUml)
+import Capabilities.WriteFile           (MonadWriteFile)
 import Modelling.ActivityDiagram.Alloy  (adConfigToAlloy)
 import Modelling.ActivityDiagram.Config (
   AdConfig (..),
@@ -171,7 +172,7 @@ matchAdSolution task =
     }
 
 matchAdTask
-  :: (MonadPlantUml m, OutputCapable m)
+  :: (MonadPlantUml m, MonadWriteFile m, OutputCapable m)
   => FilePath
   -> MatchAdInstance
   -> LangM m

--- a/src/Modelling/ActivityDiagram/MatchPetri.hs
+++ b/src/Modelling/ActivityDiagram/MatchPetri.hs
@@ -38,6 +38,7 @@ import Capabilities.Cache               (MonadCache)
 import Capabilities.Diagrams            (MonadDiagrams)
 import Capabilities.Graphviz            (MonadGraphviz)
 import Capabilities.PlantUml            (MonadPlantUml)
+import Capabilities.WriteFile           (MonadWriteFile)
 import Modelling.ActivityDiagram.Alloy  (adConfigToAlloy, modulePetriNet)
 import Modelling.ActivityDiagram.Auxiliary.Util (finalNodesAdvice)
 import Modelling.ActivityDiagram.Datatype (
@@ -291,6 +292,7 @@ matchPetriTask
     MonadGraphviz m,
     MonadPlantUml m,
     MonadThrow m,
+    MonadWriteFile m,
     OutputCapable m
     )
   => FilePath

--- a/src/Modelling/ActivityDiagram/PlantUMLConverter.hs
+++ b/src/Modelling/ActivityDiagram/PlantUMLConverter.hs
@@ -16,6 +16,7 @@ import Data.String.Interpolate ( i, __i )
 import GHC.Generics (Generic)
 
 import Capabilities.PlantUml            (MonadPlantUml (drawPlantUmlSvg))
+import Capabilities.WriteFile           (MonadWriteFile (writeToFile))
 import Modelling.ActivityDiagram.Datatype (
   AdNode (..),
   UMLActivityDiagram(..),
@@ -35,13 +36,14 @@ defaultPlantUmlConfig = PlantUmlConfig {
 }
 
 drawAdToFile
-  :: MonadPlantUml m
+  :: (MonadPlantUml m, MonadWriteFile m)
   => FilePath
   -> PlantUmlConfig
   -> UMLActivityDiagram
   -> m FilePath
 drawAdToFile path conf ad = do
-  drawPlantUmlSvg adFilename $ convertToPlantUML' conf ad
+  renderedAd <- drawPlantUmlSvg $ convertToPlantUML' conf ad
+  writeToFile adFilename renderedAd
   return adFilename
   where
     adFilename :: FilePath

--- a/src/Modelling/ActivityDiagram/SelectAS.hs
+++ b/src/Modelling/ActivityDiagram/SelectAS.hs
@@ -27,6 +27,7 @@ import qualified Data.Vector as V (fromList)
 
 import Capabilities.Alloy               (MonadAlloy, getInstances)
 import Capabilities.PlantUml            (MonadPlantUml)
+import Capabilities.WriteFile           (MonadWriteFile)
 import Modelling.ActivityDiagram.ActionSequences (generateActionSequence, validActionSequence)
 import Modelling.ActivityDiagram.Alloy (
   adConfigToAlloy,
@@ -231,7 +232,7 @@ compareDistToCorrect correctSequence xs ys =
       $ leastChanges (asEditDistParams correctSequence) (V.fromList correctSequence) (V.fromList zs)
 
 selectASTask
-  :: (MonadPlantUml m, OutputCapable m)
+  :: (MonadPlantUml m, MonadWriteFile m, OutputCapable m)
   => FilePath
   -> SelectASInstance
   -> LangM m

--- a/src/Modelling/ActivityDiagram/SelectPetri.hs
+++ b/src/Modelling/ActivityDiagram/SelectPetri.hs
@@ -29,6 +29,7 @@ import Capabilities.Cache               (MonadCache)
 import Capabilities.Diagrams            (MonadDiagrams)
 import Capabilities.Graphviz            (MonadGraphviz)
 import Capabilities.PlantUml            (MonadPlantUml)
+import Capabilities.WriteFile           (MonadWriteFile)
 import qualified Data.Map as M (empty, size, fromList, toList, keys, map, filter)
 import qualified Modelling.ActivityDiagram.Datatype as Ad (AdNode(label))
 import qualified Modelling.ActivityDiagram.PetriNet as PK (PetriKey (label))
@@ -343,6 +344,7 @@ selectPetriTask
     MonadGraphviz m,
     MonadPlantUml m,
     MonadThrow m,
+    MonadWriteFile m,
     OutputCapable m
     )
   => FilePath
@@ -408,6 +410,7 @@ selectPetriEvaluation
     MonadGraphviz m,
     MonadPlantUml m,
     MonadThrow m,
+    MonadWriteFile m,
     OutputCapable m
     )
   => FilePath

--- a/src/Modelling/PetriNet/Diagram.hs
+++ b/src/Modelling/PetriNet/Diagram.hs
@@ -18,7 +18,7 @@ import qualified Diagrams.TwoD.GraphViz           as GV (getGraph)
 import qualified Data.Map                         as M (foldlWithKey, lookupMin)
 
 import Capabilities.Cache               (MonadCache, cache, short)
-import Capabilities.Diagrams            (MonadDiagrams (lin, writeSvg))
+import Capabilities.Diagrams            (MonadDiagrams (lin, renderDiagram))
 import Capabilities.Graphviz            (MonadGraphviz (layoutGraph))
 import Modelling.Auxiliary.Common       (Object)
 import Modelling.Auxiliary.Diagrams (
@@ -83,9 +83,9 @@ cacheNet
   -- ^ how to draw the graph
   -> m FilePath
 cacheNet path pl drawSettings@DrawSettings {..} =
-  cache path ext prefix pl $ \svg pl' -> do
+  cache path ext prefix pl $ \pl' -> do
     dia <- drawNet pl' drawSettings
-    writeSvg svg dia
+    renderDiagram dia
   where
     prefix =
       "petri-"

--- a/stack-apps.yaml
+++ b/stack-apps.yaml
@@ -16,7 +16,7 @@ extra-deps:
       - output-blocks
       - output-blocks-latex
   - git: https://github.com/fmidue/autotool-capabilities.git
-    commit: fa712df18cba66ce45acfbd3c2a5fbf7ba756dbb
+    commit: 8067088f23759d787c049677a26868df26c1676f
     subdirs:
       - autotool-capabilities
       - autotool-capabilities-io-instances

--- a/stack-examples.yaml
+++ b/stack-examples.yaml
@@ -13,7 +13,7 @@ extra-deps:
     subdirs:
       - output-blocks
   - git: https://github.com/fmidue/autotool-capabilities.git
-    commit: fa712df18cba66ce45acfbd3c2a5fbf7ba756dbb
+    commit: 8067088f23759d787c049677a26868df26c1676f
     subdirs:
       - autotool-capabilities
       - autotool-capabilities-io-instances

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ extra-deps:
     subdirs:
       - output-blocks
   - git: https://github.com/fmidue/autotool-capabilities.git
-    commit: fa712df18cba66ce45acfbd3c2a5fbf7ba756dbb
+    commit: 8067088f23759d787c049677a26868df26c1676f
     subdirs:
       - autotool-capabilities
       - autotool-capabilities-io-instances


### PR DESCRIPTION
- Add `MonadWriteFile` constraints where needed and edit calls to the render interfaces.
- Import WriteFile capability in tests

@marcellussiegburg please have a look if there's something off somewhere (especially in app and legacy-app files)