### PR TITLE
overlappable MonadThrow instance

### DIFF
--- a/src/Modelling/Auxiliary/Common.hs
+++ b/src/Modelling/Auxiliary/Common.hs
@@ -82,7 +82,7 @@ data ModellingTasksException
 
 instance Exception ModellingTasksException
 
-instance MonadThrow m => MonadThrow (RandT g m) where
+instance {-# OVERLAPPABLE#-} MonadThrow m => MonadThrow (RandT g m) where
   throwM = lift . throwM
 
 mapIndicesTo :: (Eq a, MonadThrow m) => [a] -> [a] -> m [(Int, Int)]

--- a/src/Modelling/Auxiliary/Common.hs
+++ b/src/Modelling/Auxiliary/Common.hs
@@ -82,7 +82,7 @@ data ModellingTasksException
 
 instance Exception ModellingTasksException
 
-instance {-# OVERLAPPABLE#-} MonadThrow m => MonadThrow (RandT g m) where
+instance {-# OVERLAPPABLE #-} MonadThrow m => MonadThrow (RandT g m) where
   throwM = lift . throwM
 
 mapIndicesTo :: (Eq a, MonadThrow m) => [a] -> [a] -> m [(Int, Int)]


### PR DESCRIPTION
So it can be overlapped by the more specific instance in flex-tasks