### PR TITLE
export toTaskSpecificText

### DIFF
--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -25,6 +25,7 @@ module Modelling.CdOd.DifferentNames (
   getDifferentNamesTask,
   mappingShow,
   renameInstance,
+  toTaskSpecificText,
   ) where
 
 import qualified Data.Bimap                       as BM (


### PR DESCRIPTION
I need `toTaskSpecificText` to implement extracting the text content of `MappingAdvice` as pure `String`.