### PR TITLE
Make input help text optional

### DIFF
--- a/app/different-names.hs
+++ b/app/different-names.hs
@@ -22,4 +22,4 @@ main = do
   i <- either error id
      <$> runExceptT (differentNames defaultDifferentNamesConfig s seed)
   print i
-  differentNamesTask "output" i `withLang` English
+  differentNamesTask True "output" i `withLang` English

--- a/app/match-cd-od.hs
+++ b/app/match-cd-od.hs
@@ -60,4 +60,4 @@ main = do
   putStrLn $ "Segment: " ++ show s
   task <- matchCdOd config s seed
   print task
-  matchCdOdTask "" task `withLang` English
+  matchCdOdTask True "" task `withLang` English

--- a/legacy-app/different-names.hs
+++ b/legacy-app/different-names.hs
@@ -21,4 +21,4 @@ main = do
   putStrLn $ "Segment: " ++ show s
   i <- differentNames 10 defaultDifferentNamesConfig s seed
   print i
-  differentNamesTask "output" i `withLang` English
+  differentNamesTask True "output" i `withLang` English

--- a/legacy-app/match-cd-od.hs
+++ b/legacy-app/match-cd-od.hs
@@ -63,4 +63,4 @@ main = do
   putStrLn $ "Segment: " ++ show s
   task <- matchCdOd 10 config s seed
   print task
-  matchCdOdTask "" task `withLang` English
+  matchCdOdTask True "" task `withLang` English

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -117,7 +117,7 @@ import Modelling.Types (
 
 import Control.Applicative              (Alternative ((<|>)))
 import Control.Monad.Catch              (MonadCatch, MonadThrow, throwM)
-import Control.Monad.Extra              (whenJust)
+import Control.Monad.Extra              (when, whenJust)
 import Control.OutputCapable.Blocks (
   ArticleToUse (DefiniteArticle),
   GenericOutputCapable (..),
@@ -137,8 +137,10 @@ import Control.OutputCapable.Blocks.Generic.Type (
   GenericOutput (Code, Paragraph, Special, Translated),
   )
 import Control.OutputCapable.Blocks.Type (
+  Output,
   SpecialOutput,
   specialToOutputCapable,
+  toOutputCapable,
   )
 import Control.Monad.Random (
   MonadRandom,
@@ -323,11 +325,12 @@ data DifferentNamesTaskTextElement
 
 differentNamesTask
   :: (MonadCache m, MonadDiagrams m, MonadGraphviz m, MonadThrow m, OutputCapable m)
-  => FilePath
+  => Bool
+  -> FilePath
   -> DifferentNamesInstance
   -> LangM m
-differentNamesTask path task = do
-  toTaskText path task
+differentNamesTask inputHelp path task = do
+  toTaskText inputHelp path task
   paragraph simplifiedInformation
   paragraph directionsAdvice
   paragraph hoveringInformation
@@ -341,11 +344,14 @@ toTaskText
     MonadThrow m,
     OutputCapable m
     )
-  => FilePath
+  => Bool
+  -> FilePath
   -> DifferentNamesInstance
   -> LangM m
-toTaskText path task = do
+toTaskText inputHelp path task = do
   specialToOutputCapable (toTaskSpecificText path task) (taskText task)
+  when inputHelp $
+    toOutputCapable [inputHintText]
   extra $ addText task
   pure ()
 
@@ -402,12 +408,23 @@ defaultDifferentNamesTaskText = [
     english "and the following object diagram (which conforms to it):"
     german "und das folgende (dazu passende) Objektdiagramm:",
   Special GivenOd,
+  Paragraph $ singleton $ Translated $ translations $ do
+    english [iii|
+      Which relationship in the class diagram (CD) corresponds
+      to which of the links in the object diagram (OD)?
+      |]
+    german [iii|
+      Welche Beziehung im Klassendiagramm (CD)
+      entspricht welchen Links im Objektdiagramm (OD)?
+      |],
+  Special MappingAdvice
+  ]
+
+inputHintText :: Output
+inputHintText =
   Paragraph [
     Translated $ translations $ do
       english [iii|
-        Which relationship in the class diagram (CD) corresponds
-        to which of the links in the object diagram (OD)?
-        \n
         State your answer by giving a mapping of
         relationships in the CD to links in the OD.
         \n
@@ -415,9 +432,6 @@ defaultDifferentNamesTaskText = [
         b in the CD corresponds to y in the OD, write the mapping as:
         |]
       german [iii|
-        Welche Beziehung im Klassendiagramm (CD)
-        entspricht welchen Links im Objektdiagramm (OD)?
-        \n
         Geben Sie Ihre Antwort als eine Zuordnung von
         Beziehungen im CD zu Links im OD an.
         \n
@@ -425,9 +439,7 @@ defaultDifferentNamesTaskText = [
         zu y im OD korrespondieren, schreiben Sie die Zuordnung als:
         |],
     Code . uniform . show $ mappingShow differentNamesInitial
-    ],
-  Special MappingAdvice
-  ]
+    ]
 
 differentNamesInitial :: [(Name, Name)]
 differentNamesInitial = map (bimap Name Name) [("a", "x"), ("b", "y")]

--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -53,6 +53,7 @@ import Modelling.Auxiliary.Common (
 import Modelling.Auxiliary.Output (
   addPretext,
   directionsAdvice,
+  extra,
   hoveringInformation,
   simplifiedInformation,
   uniform,
@@ -120,7 +121,7 @@ import Modelling.Types (
 
 import Control.Applicative              (Alternative ((<|>)))
 import Control.Exception                (Exception)
-import Control.Monad                    ((<=<))
+import Control.Monad                    ((<=<), when)
 import Control.Monad.Catch              (MonadCatch, MonadThrow, throwM)
 #if __GLASGOW_HASKELL__ < 808
 import Control.Monad.Fail               (MonadFail)
@@ -143,8 +144,10 @@ import Control.OutputCapable.Blocks.Generic.Type (
   GenericOutput (Code, Paragraph, Special, Translated),
   )
 import Control.OutputCapable.Blocks.Type (
+  Output,
   SpecialOutput,
   specialToOutputCapable,
+  toOutputCapable,
   )
 import Control.Monad.Random (
   MonadRandom,
@@ -281,11 +284,12 @@ matchCdOdTask
     MonadThrow m,
     OutputCapable m
     )
-  => FilePath
+  => Bool
+  -> FilePath
   -> MatchCdOdInstance
   -> LangM m
-matchCdOdTask path task = do
-  toTaskText path task
+matchCdOdTask inputHelp path task = do
+  toTaskText inputHelp path task
   paragraph simplifiedInformation
   paragraph directionsAdvice
   paragraph hoveringInformation
@@ -299,11 +303,16 @@ toTaskText
     MonadThrow m,
     OutputCapable m
     )
-  => FilePath
+  => Bool
+  -> FilePath
   -> MatchCdOdInstance
   -> LangM m
-toTaskText path task =
+toTaskText inputHelp path task = do
   specialToOutputCapable (toTaskSpecificText path task) (taskText task)
+  when inputHelp $
+    toOutputCapable inputHelpText
+  extra $ addText task
+  pure ()
 
 toTaskSpecificText
   :: (
@@ -344,7 +353,11 @@ defaultMatchCdOdTaskText = [
       Ein Objektdiagramm kann zu keinem,
       einem oder beiden Klassendiagrammen passen.
       |],
-  Special GivenOds,
+  Special GivenOds
+  ]
+
+inputHelpText :: [Output]
+inputHelpText = [
   Paragraph [
     Translated $ translations $ do
       english [iii|

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -143,7 +143,7 @@ import Modelling.CdOd.Types (
 import Modelling.Types                  (Change (..))
 
 import Control.Applicative              (Alternative ((<|>)))
-import Control.Monad                    ((>=>), forM, join)
+import Control.Monad                    ((>=>), forM, join, when)
 import Control.Monad.Catch              (MonadCatch, MonadThrow)
 import Control.Monad.Except             (runExceptT)
 import Control.OutputCapable.Blocks (
@@ -171,9 +171,11 @@ import Control.OutputCapable.Blocks.Generic.Type (
   GenericOutput (Code, Paragraph, Special, Translated),
   )
 import Control.OutputCapable.Blocks.Type (
+  Output,
   SpecialOutput,
   checkTranslation,
   specialToOutputCapable,
+  toOutputCapable,
   )
 import Control.Monad.Random
   (MonadRandom, RandT, RandomGen, evalRandT, mkStdGen)
@@ -372,11 +374,15 @@ data NameCdErrorTaskTextElement =
 
 toTaskText
   :: (MonadCache m, MonadDiagrams m, MonadGraphviz m, OutputCapable m)
-  => FilePath
+  => Bool
+  -> FilePath
   -> NameCdErrorInstance
   -> LangM m
-toTaskText path task =
+toTaskText inputHelp path task = do
   specialToOutputCapable (toTaskSpecificText path task) (taskText task)
+  when inputHelp $
+    toOutputCapable inputHelpText
+  pure ()
 
 toTaskSpecificText
   :: (MonadCache m, MonadDiagrams m, MonadGraphviz m, OutputCapable m)
@@ -508,7 +514,11 @@ defaultNameCdErrorTaskText = [
   Paragraph $ singleton $ Translated $ translations $ do
     english [i|The class diagram ...|]
     german [i|Das Klassendiagramm ...|],
-  Paragraph $ singleton $ Special ReasonsList,
+  Paragraph $ singleton $ Special ReasonsList
+  ]
+
+inputHelpText :: [Output]
+inputHelpText = [
   Paragraph [
     Paragraph $ singleton $ Translated $ translations $ do
       english [iii|
@@ -549,11 +559,12 @@ defaultNameCdErrorTaskText = [
 
 nameCdErrorTask
   :: (MonadCache m, MonadDiagrams m, MonadGraphviz m, OutputCapable m)
-  => FilePath
+  => Bool
+  -> FilePath
   -> NameCdErrorInstance
   -> LangM m
-nameCdErrorTask path task = do
-  toTaskText path task
+nameCdErrorTask inputHelp path task = do
+  toTaskText inputHelp path task
   paragraph simplifiedInformation
   paragraph hoveringInformation
   extra $ addText task


### PR DESCRIPTION
I added the flag to the taskText generator functions like logic-tasks: https://github.com/fmidue/logic-tasks/blob/ee417f06c50606a7de98027b5bfd59aafdbd3c88/src/LogicTasks/Syntax/IllegalFormulas.hs?plain=1#L48

but maybe adding the flag to `*Instance` would be better?