### PR TITLE
DifferentNames: Do not discard mappings with unused class diagram links

### DIFF
--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -570,9 +570,9 @@ differentNamesEvaluation task cs = do
       mStripped = BM.mapMonotonicR stripName $ nameMapping $ mapping task
       -- Swap answer tuples around if necessary
       -- The preceding syntax check guarantees only valid pairs can be submitted here
-      readMapping pair@(left,_)
-        | BM.member left mStripped = pair
-        | otherwise = swap pair
+      readMapping pair@(_, right)
+        | BM.member right mStripped = swap pair
+        | otherwise = pair
       what = translations $ do
         german "Zuordnungen"
         english "mappings"

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -227,8 +227,8 @@ checkDifferentNamesInstance DifferentNamesInstance {..}
       but currently "#{x}" is among both.
       |]
   | let strippedODMapping = BM.map
-      stripNumericPeriod
-      $ fromNameMapping mapping,
+          stripNumericPeriod
+          $ fromNameMapping mapping,
     any (`BM.member` strippedODMapping) strippedLinks
   = Just [iii|
       Pairs given in mapping must follow this order:

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -35,6 +35,7 @@ import qualified Data.Bimap                       as BM (
   fromList,
   keys,
   lookup,
+  mapMonotonic,
   mapMonotonicR,
   member,
   toAscList,
@@ -220,10 +221,18 @@ checkDifferentNamesInstance DifferentNamesInstance {..}
       i.e., for which an association in the Class diagram exists
       but not a link in the Object diagram.
       |]
-  | (x:_) <- nubOrd links `intersect` nubOrd associations
+  | (x:_) <- nubOrd strippedLinks `intersect` nubOrd associations
   = Just [iii|
       Link names and association names must be disjoint
       but currently "#{x}" is among both.
+      |]
+  | strippedODMapping <- BM.mapMonotonic
+      stripNumericPeriod
+      $ fromNameMapping mapping,
+    any (`BM.member` strippedODMapping) strippedLinks
+  = Just [iii|
+      Pairs given in mapping must follow this order:
+      (CD association, OD link)
       |]
   | otherwise
   = checkObjectDiagram oDiagram
@@ -231,6 +240,7 @@ checkDifferentNamesInstance DifferentNamesInstance {..}
   where
     associations = associationNames cDiagram
     links = linkLabels oDiagram
+    strippedLinks = map stripNumericPeriod links
 
 data DifferentNamesConfig
   = DifferentNamesConfig {

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -37,7 +37,6 @@ import qualified Data.Bimap                       as BM (
   lookup,
   mapMonotonicR,
   member,
-  memberR,
   toAscList,
   )
 import qualified Data.Map                         as M (
@@ -561,9 +560,8 @@ differentNamesEvaluation task cs = do
       mStripped = BM.mapMonotonicR stripName $ nameMapping $ mapping task
       -- Swap answer tuples around if necessary
       -- The preceding syntax check guarantees only valid pairs can be submitted here
-      readMapping pair@(left,right)
-        | BM.member left mStripped ||
-          BM.memberR right mStripped = pair
+      readMapping pair@(left,_)
+        | BM.member left mStripped = pair
         | otherwise = swap pair
       what = translations $ do
         german "Zuordnungen"

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -36,7 +36,8 @@ import qualified Data.Bimap                       as BM (
   keys,
   lookup,
   mapMonotonicR,
-  pairMember,
+  member,
+  memberR,
   toAscList,
   )
 import qualified Data.Map                         as M (
@@ -560,10 +561,10 @@ differentNamesEvaluation task cs = do
       mStripped = BM.mapMonotonicR stripName $ nameMapping $ mapping task
       -- Swap answer tuples around if necessary
       -- The preceding syntax check guarantees only valid pairs can be submitted here
-      readMapping pair =
-        if BM.pairMember pair mStripped
-        then pair
-        else swap pair
+      readMapping pair@(left,right)
+        | BM.member left mStripped ||
+          BM.memberR right mStripped = pair
+        | otherwise = swap pair
       what = translations $ do
         german "Zuordnungen"
         english "mappings"

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -35,8 +35,8 @@ import qualified Data.Bimap                       as BM (
   fromList,
   keys,
   lookup,
-  lookupR,
   mapMonotonicR,
+  pairMember,
   toAscList,
   )
 import qualified Data.Map                         as M (
@@ -157,7 +157,6 @@ import Control.Monad.Random (
   )
 import Control.Monad.Trans.Except       (runExceptT)
 import Data.Bifunctor                   (Bifunctor (bimap, first))
-import Data.Bimap                       (Bimap)
 import Data.Bitraversable               (bitraverse)
 import Data.Bool                        (bool)
 import Data.Char                        (isDigit)
@@ -175,7 +174,6 @@ import Data.List (
   )
 import Data.Maybe (
   catMaybes,
-  isJust,
   isNothing,
   listToMaybe,
   mapMaybe,
@@ -551,15 +549,6 @@ differentNamesSyntax DifferentNamesInstance {..} cs = addPretext $ do
       (not . null . tail)
       $ group $ sort (map fst choicesStripped ++ map snd choicesStripped)
 
-readMapping :: Ord a => Bimap a a -> (a, a) -> Maybe (a, a)
-readMapping m (x, y)
-  | isJust (BM.lookup x m) || isJust (BM.lookupR y m)
-  = Just (x, y)
-  | isJust (BM.lookup y m) || isJust (BM.lookupR x m)
-  = Just (y, x)
-  | otherwise
-  = Nothing
-
 differentNamesEvaluation
   :: OutputCapable m
   => DifferentNamesInstance
@@ -569,6 +558,12 @@ differentNamesEvaluation task cs = do
   let csStripped = map (bimap stripName stripName) cs
       -- Strip periods from the mapping's link labels (second element of each pair)
       mStripped = BM.mapMonotonicR stripName $ nameMapping $ mapping task
+      -- Swap answer tuples around if necessary
+      -- The preceding syntax check guarantees only valid pairs can be submitted here
+      readMapping pair =
+        if BM.pairMember pair mStripped
+        then pair
+        else swap pair
       what = translations $ do
         german "Zuordnungen"
         english "mappings"
@@ -578,7 +573,7 @@ differentNamesEvaluation task cs = do
         then Just . (DefiniteArticle,) . show . mappingShow
           $ differentNamesSolution task
         else Nothing
-  multipleChoice what solution ms (mapMaybe (readMapping mStripped) csStripped)
+  multipleChoice what solution ms (map readMapping csStripped)
 
 differentNamesSolution :: DifferentNamesInstance -> [(Name, Name)]
 differentNamesSolution = BM.toAscList . nameMapping . mapping

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -226,7 +226,7 @@ checkDifferentNamesInstance DifferentNamesInstance {..}
       Link names and association names must be disjoint
       but currently "#{x}" is among both.
       |]
-  | strippedODMapping <- BM.map
+  | let strippedODMapping = BM.map
       stripNumericPeriod
       $ fromNameMapping mapping,
     any (`BM.member` strippedODMapping) strippedLinks

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -35,8 +35,8 @@ import qualified Data.Bimap                       as BM (
   fromList,
   keys,
   lookup,
-  mapMonotonic,
-  mapMonotonicR,
+  map,
+  mapR,
   member,
   toAscList,
   )
@@ -226,7 +226,7 @@ checkDifferentNamesInstance DifferentNamesInstance {..}
       Link names and association names must be disjoint
       but currently "#{x}" is among both.
       |]
-  | strippedODMapping <- BM.mapMonotonic
+  | strippedODMapping <- BM.map
       stripNumericPeriod
       $ fromNameMapping mapping,
     any (`BM.member` strippedODMapping) strippedLinks
@@ -566,17 +566,18 @@ differentNamesEvaluation
   -> Rated m
 differentNamesEvaluation task cs = do
   let csStripped = map (bimap stripName stripName) cs
-      -- Strip periods from the mapping's link labels (second element of each pair)
-      mStripped = BM.mapMonotonicR stripName $ nameMapping $ mapping task
+      correctMapping = nameMapping $ mapping task
       -- Swap answer tuples around if necessary
       -- The preceding syntax check guarantees only valid pairs can be submitted here
       readMapping pair@(_, right)
-        | BM.member right mStripped = swap pair
+        | BM.member right correctMapping = swap pair
         | otherwise = pair
       what = translations $ do
         german "Zuordnungen"
         english "mappings"
-      ms = M.fromAscList $ map (,True) $ BM.toAscList mStripped
+      -- Strip periods from the mapping's link labels (second element of each pair)
+      ms = M.fromAscList $ map (,True) $ BM.toAscList
+        $ BM.mapR stripName correctMapping
       solution =
         if showSolution task
         then Just . (DefiniteArticle,) . show . mappingShow

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -41,7 +41,7 @@ import qualified Data.Bimap                       as BM (
   toAscList,
   )
 import qualified Data.Map                         as M (
-  fromAscList,
+  fromDistinctAscList,
   )
 
 import Autolib.Hash                     (Hashable)
@@ -576,7 +576,7 @@ differentNamesEvaluation task cs = do
         german "Zuordnungen"
         english "mappings"
       -- Strip periods from the mapping's link labels (second element of each pair)
-      ms = M.fromAscList $ map (,True) $ BM.toAscList
+      ms = M.fromDistinctAscList $ map (,True) $ BM.toAscList
         $ BM.mapR stripName correctMapping
       solution =
         if showSolution task

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -523,9 +523,9 @@ differentNamesSyntax DifferentNamesInstance {..} cs = addPretext $ do
 
 readMapping :: Ord a => Bimap a a -> (a, a) -> Maybe (a, a)
 readMapping m (x, y)
-  | isJust $ BM.lookup x m, isJust $ BM.lookupR y m
+  | isJust (BM.lookup x m) || isJust (BM.lookupR y m)
   = Just (x, y)
-  | isJust $ BM.lookup y m, isJust $ BM.lookupR x m
+  | isJust (BM.lookup y m) || isJust (BM.lookupR x m)
   = Just (y, x)
   | otherwise
   = Nothing

--- a/src/Modelling/CdOd/DifferentNames.hs
+++ b/src/Modelling/CdOd/DifferentNames.hs
@@ -576,8 +576,7 @@ differentNamesEvaluation task cs = do
         german "Zuordnungen"
         english "mappings"
       -- Strip periods from the mapping's link labels (second element of each pair)
-      ms = M.fromDistinctAscList $ map (,True) $ BM.toAscList
-        $ BM.mapR stripName correctMapping
+      ms = M.fromDistinctAscList $ map (,True) $ BM.toAscList $ BM.mapR stripName correctMapping
       solution =
         if showSolution task
         then Just . (DefiniteArticle,) . show . mappingShow


### PR DESCRIPTION
This caused feedback to assert

**All indicated mappings are correct?**
```
Yes.
```

even when wrong mappings were present.
