### PR TITLE
statistics of match-cd-od tasks

### DIFF
--- a/example/src/Modelling/CdOd/DifferentNames/Config.hs
+++ b/example/src/Modelling/CdOd/DifferentNames/Config.hs
@@ -339,7 +339,7 @@ task2025_14 = DifferentNamesConfig {
 points: 0.15
 variant 1: concepts are printed in class diagrams
 share same instances as task2025_14
-average concept generation time per instance: 10~15 mins
+average concept generation time per instance (no concurrency): 10~15 mins
 used LLM model for generation: gpt-5
 approximate input tokens: 3.575 M (1.25 $ / 1M tokens)
 approximate output tokens: 4.437 M (10 $ / 1M tokens)

--- a/example/src/Modelling/CdOd/DifferentNames/Config.hs
+++ b/example/src/Modelling/CdOd/DifferentNames/Config.hs
@@ -297,7 +297,7 @@ task2025_13 = DifferentNamesConfig {
 points: 0.15
 the amount of generated instances: 100
 maximum concurrent amount of tasks: 20
-average generation time per instance on the cluster: 2:28min
+average generation time per instance on the cluster (without considering concurrency): 2:28min
 total run time on the cluster (not including queuing time): 16:14min
 -}
 task2025_14 :: DifferentNamesConfig

--- a/example/src/Modelling/CdOd/DifferentNames/Config.hs
+++ b/example/src/Modelling/CdOd/DifferentNames/Config.hs
@@ -296,7 +296,9 @@ task2025_13 = DifferentNamesConfig {
 {-|
 points: 0.15
 the amount of generated instances: 100
+maximum concurrent amount of tasks: 20
 average generation time per instance on the cluster: 2:28min
+total run time on the cluster (not including queuing time): 16:14min
 -}
 task2025_14 :: DifferentNamesConfig
 task2025_14 = DifferentNamesConfig {

--- a/example/src/Modelling/CdOd/MatchCdOd/Config.hs
+++ b/example/src/Modelling/CdOd/MatchCdOd/Config.hs
@@ -406,7 +406,9 @@ task2024_59 = MatchCdOdConfig {
 {-|
 points: 0.15
 the amount of generated instances: 100
+maximum concurrent amount of tasks: 50
 average generation time per instance on the cluster: 19:18min
+total run time on the cluster (not including queuing time): 1:10:30h
 average CPU usage: 175.75%
 average memory usage: 3777 MB
 -}
@@ -416,7 +418,9 @@ task2025_17 = task2024_17
 {-|
 points: 0.15
 the amount of generated instances: 100
+maximum concurrent amount of tasks: 50
 average generation time per instance on the cluster: 8:20min
+total run time on the cluster (not including queuing time): 18:21min
 average CPU usage: 107.96%
 average memory usage: 3792 MB
 -}
@@ -426,7 +430,9 @@ task2025_18 = task2024_18
 {-|
 points: 0.15
 the amount of generated instances: 100
+maximum concurrent amount of tasks: 50
 average generation time per instance on the cluster: 12:07min
+total run time on the cluster (not including queuing time): 33:51min
 average CPU usage: 106.16%
 average memory usage: 5232.74 MB
 -}
@@ -436,7 +442,9 @@ task2025_19 = task2024_19
 {-|
 points: 0.15
 the amount of generated instances: 100
+maximum concurrent amount of tasks: 50
 average generation time per instance on the cluster: 7:54min
+total run time on the cluster (not including queuing time): 19:07min
 average CPU usage: 105.74%
 average memory usage: 3530.61 MB
 -}

--- a/example/src/Modelling/CdOd/MatchCdOd/Config.hs
+++ b/example/src/Modelling/CdOd/MatchCdOd/Config.hs
@@ -407,7 +407,7 @@ task2024_59 = MatchCdOdConfig {
 points: 0.15
 the amount of generated instances: 100
 maximum concurrent amount of tasks: 50
-average generation time per instance on the cluster: 19:18min
+average generation time per instance on the cluster (without considering concurrency): 19:18min
 total run time on the cluster (not including queuing time): 1:10:30h
 average CPU usage: 175.75%
 average memory usage: 3777 MB
@@ -419,7 +419,7 @@ task2025_17 = task2024_17
 points: 0.15
 the amount of generated instances: 100
 maximum concurrent amount of tasks: 50
-average generation time per instance on the cluster: 8:20min
+average generation time per instance on the cluster (without considering concurrency): 8:20min
 total run time on the cluster (not including queuing time): 18:21min
 average CPU usage: 107.96%
 average memory usage: 3792 MB
@@ -431,7 +431,7 @@ task2025_18 = task2024_18
 points: 0.15
 the amount of generated instances: 100
 maximum concurrent amount of tasks: 50
-average generation time per instance on the cluster: 12:07min
+average generation time per instance on the cluster (without considering concurrency): 12:07min
 total run time on the cluster (not including queuing time): 33:51min
 average CPU usage: 106.16%
 average memory usage: 5232.74 MB
@@ -443,7 +443,7 @@ task2025_19 = task2024_19
 points: 0.15
 the amount of generated instances: 100
 maximum concurrent amount of tasks: 50
-average generation time per instance on the cluster: 7:54min
+average generation time per instance on the cluster (without considering concurrency): 7:54min
 total run time on the cluster (not including queuing time): 19:07min
 average CPU usage: 105.74%
 average memory usage: 3530.61 MB

--- a/example/src/Modelling/CdOd/MatchCdOd/Config.hs
+++ b/example/src/Modelling/CdOd/MatchCdOd/Config.hs
@@ -403,14 +403,42 @@ task2024_59 = MatchCdOdConfig {
   extraText = NoExtraText
   }
 
+{-|
+points: 0.15
+the amount of generated instances: 100
+average generation time per instance on the cluster: 19:18min
+average CPU usage: 175.75%
+average memory usage: 3777 MB
+-}
 task2025_17 :: MatchCdOdConfig
 task2025_17 = task2024_17
 
+{-|
+points: 0.15
+the amount of generated instances: 100
+average generation time per instance on the cluster: 8:20min
+average CPU usage: 107.96%
+average memory usage: 3792 MB
+-}
 task2025_18 :: MatchCdOdConfig
 task2025_18 = task2024_18
 
+{-|
+points: 0.15
+the amount of generated instances: 100
+average generation time per instance on the cluster: 12:07min
+average CPU usage: 106.16%
+average memory usage: 5232.74 MB
+-}
 task2025_19 :: MatchCdOdConfig
 task2025_19 = task2024_19
 
+{-|
+points: 0.15
+the amount of generated instances: 100
+average generation time per instance on the cluster: 7:54min
+average CPU usage: 105.74%
+average memory usage: 3530.61 MB
+-}
 task2025_20 :: MatchCdOdConfig
 task2025_20 = task2024_20


### PR DESCRIPTION
Average CPU and memory usage is also recorded for `match-cd-od` besides average time, but they are not available for `DifferentNames`, because I previously forgot adding them in the scripts.