### PR TITLE
Expose NameCdError answer texts

### DIFF
--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -516,6 +516,9 @@ checkNameCdErrorInstance NameCdErrorInstance {..}
       . filter isRelevant
       $ annotatedRelationships classDiagram
 
+defaultNameCdErrorTaskText :: NameCdErrorTaskText
+defaultNameCdErrorTaskText = nameCdErrorTaskText True
+
 nameCdErrorTaskText :: Bool -> NameCdErrorTaskText
 nameCdErrorTaskText withAnswerChoices = concat [
  [
@@ -555,9 +558,6 @@ nameCdErrorTaskText withAnswerChoices = concat [
  ]]
  where
     optional cond xs = if cond then xs else []
-
-defaultNameCdErrorTaskText :: NameCdErrorTaskText
-defaultNameCdErrorTaskText = nameCdErrorTaskText True
 
 inputHelpText :: [Output]
 inputHelpText = [

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -32,8 +32,10 @@ module Modelling.CdOd.NameCdError (
   nameCdErrorSyntax,
   nameCdErrorTask,
   nameCdErrorTaskText,
+  relevantRelationships,
   renameInstance,
   translateReason,
+  translateRelationship,
   ) where
 
 import qualified Modelling.CdOd.CdAndChanges.Transform as Changes (
@@ -418,18 +420,29 @@ toTaskSpecificText path task@NameCdErrorInstance {..} = \case
       $ map (second (renderReason (printNavigations cdDrawSettings) . snd))
       $ M.toList errorReasons
     RelationshipsList -> do
-      let defaults = omittedDefaults cdDrawSettings
-          phrase article x y z = translate $ do
-            english $ phraseRelationship English defaults article Denoted x y z
-            german $ phraseRelationship German defaults article Denoted x y z
-          phraseRelationship' Annotation {..} = phrase
-            (referenceUsing annotation)
+      let phraseRelationship' annotation = translateRelationship
+            cdDrawSettings
             byName
-            (printNavigations cdDrawSettings)
-            annotated
+            annotation
       enumerateM (text . show)
-        $ map (second phraseRelationship')
+        $ map (second (translate . put . phraseRelationship'))
         $ relevantRelationships task
+
+translateRelationship
+  :: CdDrawSettings
+  -> Bool
+  -> Annotation Relevance (AnyRelationship String String)
+  -> Map Language String
+translateRelationship cdDrawSettings byName Annotation {..} =
+  let defaults = omittedDefaults cdDrawSettings
+      phrase article x y z = translations $ do
+        english $ phraseRelationship English defaults article Denoted x y z
+        german $ phraseRelationship German defaults article Denoted x y z
+  in phrase
+    (referenceUsing annotation)
+    byName
+    (printNavigations cdDrawSettings)
+    annotated
 
 data NameCdErrorInstance = NameCdErrorInstance {
   byName                      :: !Bool,

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -31,7 +31,9 @@ module Modelling.CdOd.NameCdError (
   nameCdErrorSolution,
   nameCdErrorSyntax,
   nameCdErrorTask,
+  nameCdErrorTaskText,
   renameInstance,
+  translateReason,
   ) where
 
 import qualified Modelling.CdOd.CdAndChanges.Transform as Changes (
@@ -236,10 +238,10 @@ isCustom = \case
   PreDefined {} -> False
 
 renderReason :: OutputCapable m => Bool -> Reason -> LangM m
-renderReason withDirections = translate . put . toTranslations withDirections
+renderReason withDirections = translate . put . translateReason withDirections
 
-toTranslations :: Bool -> Reason -> Map Language String
-toTranslations withDirections = \case
+translateReason :: Bool -> Reason -> Map Language String
+translateReason withDirections = \case
   Custom x -> x
   PreDefined x -> translateProperty withDirections x
 
@@ -490,7 +492,7 @@ checkNameCdErrorInstance NameCdErrorInstance {..}
   = Just [iii|
       'errorReasons' contains duplicate '#{x}' which is not allowed.
       |]
-  | x:_ <- concatMap (checkTranslation . toTranslations True) reasons
+  | x:_ <- concatMap (checkTranslation . translateReason True) reasons
   = Just $ [i|Problem within 'errorReasons': |] ++ x
   | otherwise
   = checkTaskText taskText
@@ -502,16 +504,21 @@ checkNameCdErrorInstance NameCdErrorInstance {..}
       . filter isRelevant
       $ annotatedRelationships classDiagram
 
-defaultNameCdErrorTaskText :: NameCdErrorTaskText
-defaultNameCdErrorTaskText = [
+nameCdErrorTaskText :: Bool -> NameCdErrorTaskText
+nameCdErrorTaskText withAnswerChoices = concat [
+ [
   Paragraph $ singleton $ Translated $ translations $ do
     english "Consider the following class diagram, which unfortunately is invalid:"
     german "Betrachten Sie folgendes Klassendiagramm, welches leider ungültig ist:",
-  Paragraph $ singleton $ Special IncorrectCd,
+  Paragraph $ singleton $ Special IncorrectCd
+ ],
+ optional withAnswerChoices [
   Paragraph $ singleton $ Translated $ translations $ do
     english "It contains the following relationships between classes:"
     german "Es enthält die folgenden Beziehungen zwischen Klassen:",
-  Paragraph $ singleton $ Special RelationshipsList,
+  Paragraph $ singleton $ Special RelationshipsList
+ ],
+ [
   Paragraph $ singleton $ Translated $ translations $ do
     english [iii|
       Choose what you think is the single reason that this class diagram is invalid,
@@ -523,7 +530,9 @@ defaultNameCdErrorTaskText = [
       dass dieses Klassendiagramm ungültig ist,
       und nennen Sie alle Beziehungen, die definitiv zum Problem beitragen,
       d.h., deren Entfernung die Ungültigkeit jeweils beheben würde.
-      |],
+      |]
+ ],
+ optional withAnswerChoices [
   Paragraph $ singleton $ Translated $ translations $ do
     english [i|Reasons available to choose from are:|]
     german [i|Gründe, die hierfür zur Auswahl stehen, sind:|],
@@ -531,7 +540,12 @@ defaultNameCdErrorTaskText = [
     english [i|The class diagram ...|]
     german [i|Das Klassendiagramm ...|],
   Paragraph $ singleton $ Special ReasonsList
-  ]
+ ]]
+ where
+    optional cond xs = if cond then xs else []
+
+defaultNameCdErrorTaskText :: NameCdErrorTaskText
+defaultNameCdErrorTaskText = nameCdErrorTaskText True
 
 inputHelpText :: [Output]
 inputHelpText = [

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -420,10 +420,9 @@ toTaskSpecificText path task@NameCdErrorInstance {..} = \case
       $ map (second (renderReason (printNavigations cdDrawSettings) . snd))
       $ M.toList errorReasons
     RelationshipsList -> do
-      let phraseRelationship' annotation = translateRelationship
+      let phraseRelationship' = translateRelationship
             cdDrawSettings
             byName
-            annotation
       enumerateM (text . show)
         $ map (second (translate . put . phraseRelationship'))
         $ relevantRelationships task


### PR DESCRIPTION
for the purpose of showing possible answers in the custom_form <https://git.uni-due.de/fmi/autotool-dev/-/issues/57#note_233475>

1. exposes functions to construct the translations of possible answers in NameCdError
2. expose a function to construct a version of defaultNameCdErrorTaskText that excludes the possible solutions since they will be shown in the custom_form already

