### PR TITLE
adjust test names to not overlap for a renaming

### DIFF
--- a/test/Modelling/CdOd/DifferentNamesSpec.hs
+++ b/test/Modelling/CdOd/DifferentNamesSpec.hs
@@ -304,7 +304,7 @@ renameProperty p = property $ \n1 n2 n3 n4 a1 a2 a3 l1 l2 l3 ->
       ls = map unName [l1, l2, l3]
       distinct xs = length (nubOrd xs) == length xs
       renamedInstance = renameInstance inst ns as ls
-  in distinct (map lowerFirst ns ++ as ++ ls)
+  in distinct (map lowerFirst ns) && distinct (ns ++ as ++ ls)
      ==> p inst renamedInstance as ls
 
 instance Arbitrary Name where

--- a/test/Modelling/CdOd/DifferentNamesSpec.hs
+++ b/test/Modelling/CdOd/DifferentNamesSpec.hs
@@ -304,7 +304,7 @@ renameProperty p = property $ \n1 n2 n3 n4 a1 a2 a3 l1 l2 l3 ->
       ls = map unName [l1, l2, l3]
       distinct xs = length (nubOrd xs) == length xs
       renamedInstance = renameInstance inst ns as ls
-  in distinct (map lowerFirst ns) && distinct as && distinct ls
+  in distinct (map lowerFirst ns ++ as ++ ls)
      ==> p inst renamedInstance as ls
 
 instance Arbitrary Name where


### PR DESCRIPTION
This test failed sporadically after adjusting `DifferentNamesEvaluation` to rely more on `DifferentNamesSyntax`' guarantees. It produces overlapping link and association names that cannot be entered by a student, as this would be prevented by  `DifferentNamesSyntax`. The test itself jumps to `DifferentNamesEvaluation` right away, but does not make sure overlap does not exist.

I went ahead and also included the class names in the distinct check, as I can't imagine we ever want to have exactly overlapping class and relationship names.