### PR TITLE
Add support for variable amount of class and object diagrams

### DIFF
--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -81,7 +81,7 @@ import Modelling.CdOd.Auxiliary.Util (
   alloyInstanceToOd,
   )
 import Modelling.CdOd.Output            (cacheCd, cacheOd)
-import Modelling.CdOd.Phrasing          (numberToWord)
+import Modelling.CdOd.Phrasing          (numberWords)
 import Modelling.CdOd.Types (
   Cd,
   CdDrawSettings (..),
@@ -351,7 +351,7 @@ defaultMatchCdOdTaskText
 defaultMatchCdOdTaskText diagramCount instanceCount =  [
   Paragraph $ singleton $ Translated $ translations $ do
     let plural     = diagramCount > 1
-        numberWord = numberToWordNumeralFallback diagramCount
+        numberWord = fromMaybe (show diagramCount) . M.lookup diagramCount . numberWords
 
     english $ "Consider the following " ++
               if plural
@@ -365,7 +365,7 @@ defaultMatchCdOdTaskText diagramCount instanceCount =  [
   Paragraph $ singleton $ Translated $ translations $ do
     let plural      = instanceCount > 1
         multipleCds = diagramCount > 1
-        numberWord  = numberToWordNumeralFallback instanceCount
+        numberWord  = fromMaybe (show instanceCount) . M.lookup instanceCount . numberWords
 
     english $
       (if plural
@@ -399,8 +399,6 @@ defaultMatchCdOdTaskText diagramCount instanceCount =  [
       else "",
   Special GivenOds
   ]
-  where
-    numberToWordNumeralFallback n = fromMaybe (show n) . numberToWord n
 
 inputHelpText :: [Output]
 inputHelpText = [

--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -80,7 +80,7 @@ import Modelling.CdOd.Auxiliary.Util (
   alloyInstanceToOd,
   )
 import Modelling.CdOd.Output            (cacheCd, cacheOd)
-import Modelling.CdOd.Phrasing          (num2word)
+import Modelling.CdOd.Phrasing          (numberToWord)
 import Modelling.CdOd.Types (
   Cd,
   CdDrawSettings (..),
@@ -353,7 +353,7 @@ defaultMatchCdOdTaskText
 defaultMatchCdOdTaskText diagramCount instanceCount =  [
   Paragraph $ singleton $ Translated $ translations $ do
     let plural     = diagramCount > 1
-    let numberWord = num2wordNumeralFallback diagramCount
+    let numberWord = numberToWordNumeralFallback diagramCount
 
     english $ "Consider the following " ++
               if plural
@@ -369,7 +369,7 @@ defaultMatchCdOdTaskText diagramCount instanceCount =  [
   Paragraph $ singleton $ Translated $ translations $ do
     let plural      = instanceCount > 1
     let multipleCds = diagramCount > 1
-    let numberWord  = num2wordNumeralFallback instanceCount
+    let numberWord  = numberToWordNumeralFallback instanceCount
 
     english $
       (if plural
@@ -404,7 +404,7 @@ defaultMatchCdOdTaskText diagramCount instanceCount =  [
   Special GivenOds
   ]
   where
-    num2wordNumeralFallback n lang = fromMaybe (show n) (num2word n lang)
+    numberToWordNumeralFallback n lang = fromMaybe (show n) (numberToWord n lang)
 
 inputHelpText :: [Output]
 inputHelpText = [

--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -38,6 +38,7 @@ import qualified Data.Map                         as M (
   fromList,
   keys,
   lookup,
+  map,
   size,
   toList,
   traverseWithKey,
@@ -239,12 +240,9 @@ defaultMatchCdOdConfig
     extraText        = NoExtraText
   }
 
-toMatching :: Map Char [Int] -> Map (Int, Char) Bool
-toMatching m =
-  M.fromList [((cd, od), any (cd `elem`) $ M.lookup od m) | cd <- cds, od <- ods]
-  where
-    cds = take 2 [1 ..]
-    ods = take 5 ['a' ..]
+toMatching :: [Int] -> Map Char [Int] -> Map (Int, Char) Bool
+toMatching cds m =
+  M.fromList [((cd, od), cd `elem` cdList) | cd <- cds, (od, cdList) <- M.toList m]
 
 checkMatchCdOdConfig :: MatchCdOdConfig -> Maybe String
 checkMatchCdOdConfig MatchCdOdConfig {..}
@@ -482,7 +480,7 @@ matchCdOdEvaluation
 matchCdOdEvaluation task sub' = do
   let sub = toMatching' sub'
       sol = fst <$> instances task
-      matching = toMatching sol
+      matching = toMatching (M.keys $ diagrams task) sol
       what = translations $ do
         english "instances"
         german "Instanzen"
@@ -498,12 +496,12 @@ matchCdOdEvaluation task sub' = do
       foldr (\(c, ys) xs -> foldr ((:) . (c,)) xs (lettersList ys)) []
 
 matchCdOdSolution :: MatchCdOdInstance -> [(Int, Letters)]
-matchCdOdSolution = M.toList . reverseMapping . fmap fst . instances
+matchCdOdSolution task = M.toList $ reverseMapping (fst <$> instances task)
   where
     reverseMapping :: Map Char [Int] -> Map Int Letters
     reverseMapping = fmap (fmap Letters) . M.foldrWithKey
       (\x ys xs -> foldr (M.adjust (x:)) xs ys)
-      $ M.fromList [(1, []), (2, [])]
+      $ M.map (const []) (diagrams task)
 
 matchCdOd
   :: (MonadAlloy m, MonadCatch m, MonadFail m)

--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -38,6 +38,7 @@ import qualified Data.Map                         as M (
   fromList,
   keys,
   lookup,
+  size,
   toList,
   traverseWithKey,
   )
@@ -79,6 +80,7 @@ import Modelling.CdOd.Auxiliary.Util (
   alloyInstanceToOd,
   )
 import Modelling.CdOd.Output            (cacheCd, cacheOd)
+import Modelling.CdOd.Phrasing          (num2word)
 import Modelling.CdOd.Types (
   Cd,
   CdDrawSettings (..),
@@ -145,6 +147,7 @@ import Control.OutputCapable.Blocks (
   multipleChoice,
   translate,
   translations,
+  Language (English, German),
   )
 import Control.OutputCapable.Blocks.Generic.Type (
   GenericOutput (Code, Paragraph, Special, Translated),
@@ -168,7 +171,7 @@ import Data.Containers.ListUtils        (nubOrd)
 import Data.GraphViz                    (DirType (Forward))
 import Data.List                        (singleton)
 import Data.Map                         (Map)
-import Data.Maybe                       (fromJust, isJust, listToMaybe, mapMaybe)
+import Data.Maybe                       (fromJust, isJust, listToMaybe, mapMaybe, fromMaybe)
 import Data.Ratio                       ((%))
 import Data.String.Interpolate          (iii)
 import GHC.Generics                     (Generic)
@@ -343,27 +346,65 @@ toTaskSpecificText path MatchCdOdInstance {..} = \case
     $=<< (\_ (is,o) -> (is,) <$> cacheOd o Forward True path)
     `M.traverseWithKey` instances
 
-defaultMatchCdOdTaskText :: MatchCdOdTaskText
-defaultMatchCdOdTaskText = [
+defaultMatchCdOdTaskText
+    :: Int
+    -> Int
+    -> MatchCdOdTaskText
+defaultMatchCdOdTaskText diagramCount instanceCount =  [
   Paragraph $ singleton $ Translated $ translations $ do
-    english "Consider the following two (valid) class diagrams:"
-    german "Betrachten Sie die folgenden zwei (gültigen) Klassendiagramme:",
+    let plural     = diagramCount > 1
+    let numberWord = num2wordNumeralFallback diagramCount
+
+    english $ "Consider the following " ++
+              if plural
+              then [iii|#{numberWord English} (valid)
+                   class diagrams:|]
+              else "(valid) class diagram:"
+    german  $ "Betrachten Sie " ++
+              if plural
+              then [iii|die folgenden #{numberWord German}
+                   (gültigen) Klassendiagramme:|]
+              else "das folgende (gültige) Klassendiagramm:",
   Special GivenCds,
   Paragraph $ singleton $ Translated $ translations $ do
-    english [iii|
-      Which of the following five object diagrams conform to which class diagram?
-      \n
-      An object diagram can conform to neither, either, or both class diagrams.
-      |]
-    german [iii|
-      Welche der folgenden fünf Objektdiagramme
-      passen zu welchem Klassendiagramm?
-      \n
-      Ein Objektdiagramm kann zu keinem,
-      einem oder beiden Klassendiagrammen passen.
-      |],
+    let plural      = instanceCount > 1
+    let multipleCds = diagramCount > 1
+    let numberWord  = num2wordNumeralFallback instanceCount
+
+    english $
+      (if plural
+      then [iii|
+        Which of the following #{numberWord English} object diagrams
+        conform to #{if multipleCds then "which" else "the"}
+        class diagram?|]
+      else
+        if multipleCds
+        then "To which class diagram does the following object diagram conform?"
+        else "Does the following object diagram conform to the class diagram?") ++
+      if multipleCds
+      then [iii|
+        \nAn object diagram can conform to none, one,
+        or multiple class diagrams.|]
+      else ""
+    german $
+      (if plural
+      then [iii|
+        Welche der folgenden #{numberWord German} Objektdiagramme
+        passen zu #{if multipleCds then "welchem" else "dem"}
+        Klassendiagramm?|]
+      else
+        if multipleCds
+        then "Zu welchem Klassendiagramm passt das folgende Objektdiagramm?"
+        else "Passt das folgende Objektdiagramm zu dem Klassendiagramm?") ++
+      if multipleCds
+      then [iii|
+        \nEin Objektdiagramm kann zu keinem, einem
+        oder mehreren Klassendiagrammen passen.|]
+      else "",
   Special GivenOds
   ]
+  where
+    num2wordNumeralFallback n lang = fromMaybe (show n) (num2word n lang)
 
 inputHelpText :: [Output]
 inputHelpText = [
@@ -497,7 +538,7 @@ getMatchCdOdTask f config@MatchCdOdConfig {..} = do
         diagrams       = cds,
         instances      = ods',
         showSolution = printSolution,
-        taskText = defaultMatchCdOdTaskText,
+        taskText = defaultMatchCdOdTaskText (M.size cds) (M.size ods),
         addText = extraText
         }
   where
@@ -678,7 +719,7 @@ defaultMatchCdOdInstance = MatchCdOdInstance {
       }))
     ],
   showSolution = True,
-  taskText = defaultMatchCdOdTaskText,
+  taskText = defaultMatchCdOdTaskText 2 5,
   addText = NoExtraText
   }
 

--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -538,7 +538,7 @@ getMatchCdOdTask f config@MatchCdOdConfig {..} = do
         diagrams       = cds,
         instances      = ods',
         showSolution = printSolution,
-        taskText = defaultMatchCdOdTaskText (M.size cds) (M.size ods),
+        taskText = defaultMatchCdOdTaskText (M.size cds) (M.size ods'),
         addText = extraText
         }
   where

--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -351,23 +351,21 @@ defaultMatchCdOdTaskText
 defaultMatchCdOdTaskText diagramCount instanceCount =  [
   Paragraph $ singleton $ Translated $ translations $ do
     let plural     = diagramCount > 1
-    let numberWord = numberToWordNumeralFallback diagramCount
+        numberWord = numberToWordNumeralFallback diagramCount
 
     english $ "Consider the following " ++
               if plural
-              then [iii|#{numberWord English} (valid)
-                   class diagrams:|]
+              then [iii|#{numberWord English} (valid) class diagrams:|]
               else "(valid) class diagram:"
     german  $ "Betrachten Sie " ++
               if plural
-              then [iii|die folgenden #{numberWord German}
-                   (gültigen) Klassendiagramme:|]
+              then [iii|die folgenden #{numberWord German} (gültigen) Klassendiagramme:|]
               else "das folgende (gültige) Klassendiagramm:",
   Special GivenCds,
   Paragraph $ singleton $ Translated $ translations $ do
     let plural      = instanceCount > 1
-    let multipleCds = diagramCount > 1
-    let numberWord  = numberToWordNumeralFallback instanceCount
+        multipleCds = diagramCount > 1
+        numberWord  = numberToWordNumeralFallback instanceCount
 
     english $
       (if plural
@@ -402,7 +400,7 @@ defaultMatchCdOdTaskText diagramCount instanceCount =  [
   Special GivenOds
   ]
   where
-    numberToWordNumeralFallback n lang = fromMaybe (show n) (numberToWord n lang)
+    numberToWordNumeralFallback n = fromMaybe (show n) . numberToWord n
 
 inputHelpText :: [Output]
 inputHelpText = [

--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -380,7 +380,7 @@ defaultMatchCdOdTaskText diagramCount instanceCount =  [
       if multipleCds
       then [iii|
         \nAn object diagram can conform to none, one,
-        or multiple class diagrams.|]
+        or multiple of the given class diagrams.|]
       else ""
     german $
       (if plural
@@ -395,7 +395,7 @@ defaultMatchCdOdTaskText diagramCount instanceCount =  [
       if multipleCds
       then [iii|
         \nEin Objektdiagramm kann zu keinem, einem
-        oder mehreren Klassendiagrammen passen.|]
+        oder mehreren der gegebenen Klassendiagramme passen.|]
       else "",
   Special GivenOds
   ]

--- a/src/Modelling/CdOd/Phrasing.hs
+++ b/src/Modelling/CdOd/Phrasing.hs
@@ -4,13 +4,13 @@ module Modelling.CdOd.Phrasing (
   phraseChange,
   phraseRelationship,
   trailingCommaGerman,
-  numberToWord,
+  numberWords,
   ) where
 
 import qualified Modelling.CdOd.Phrasing.German    as German
 import qualified Modelling.CdOd.Phrasing.English   as English
 
-import qualified Data.Map as M (lookup)
+import Data.Map (Map)
 
 import Control.OutputCapable.Blocks (
   ArticleToUse,
@@ -50,12 +50,10 @@ phraseRelationship = \case
   English -> English.phraseRelationship
   German -> German.phraseRelationship
 
-numberToWord :: Int -> Language -> Maybe String
-numberToWord n = M.lookup n . numberWords
-  where
-    numberWords = \case
-      English -> English.numberWords
-      German  -> German.numberWords
+numberWords :: Language -> Map Int String
+numberWords = \case
+  English -> English.numberWords
+  German  -> German.numberWords
 
 trailingCommaGerman :: String -> String
 trailingCommaGerman = German.trailingComma

--- a/src/Modelling/CdOd/Phrasing.hs
+++ b/src/Modelling/CdOd/Phrasing.hs
@@ -51,9 +51,9 @@ phraseRelationship = \case
   German -> German.phraseRelationship
 
 numberToWord :: Int -> Language -> Maybe String
-numberToWord n lang = M.lookup n numberWords
+numberToWord n = M.lookup n . numberWords
   where
-    numberWords = case lang of
+    numberWords = \case
       English -> English.numberWords
       German  -> German.numberWords
 

--- a/src/Modelling/CdOd/Phrasing.hs
+++ b/src/Modelling/CdOd/Phrasing.hs
@@ -4,7 +4,7 @@ module Modelling.CdOd.Phrasing (
   phraseChange,
   phraseRelationship,
   trailingCommaGerman,
-  num2word,
+  numberToWord,
   ) where
 
 import qualified Modelling.CdOd.Phrasing.German    as German
@@ -50,8 +50,8 @@ phraseRelationship = \case
   English -> English.phraseRelationship
   German -> German.phraseRelationship
 
-num2word :: Int -> Language -> Maybe String
-num2word n lang = M.lookup n numberWords
+numberToWord :: Int -> Language -> Maybe String
+numberToWord n lang = M.lookup n numberWords
   where
     numberWords = case lang of
       English -> English.numberWords

--- a/src/Modelling/CdOd/Phrasing.hs
+++ b/src/Modelling/CdOd/Phrasing.hs
@@ -4,10 +4,13 @@ module Modelling.CdOd.Phrasing (
   phraseChange,
   phraseRelationship,
   trailingCommaGerman,
+  num2word,
   ) where
 
 import qualified Modelling.CdOd.Phrasing.German    as German
 import qualified Modelling.CdOd.Phrasing.English   as English
+
+import qualified Data.Map as M (lookup)
 
 import Control.OutputCapable.Blocks (
   ArticleToUse,
@@ -46,6 +49,13 @@ phraseRelationship
 phraseRelationship = \case
   English -> English.phraseRelationship
   German -> German.phraseRelationship
+
+num2word :: Int -> Language -> Maybe String
+num2word n lang = M.lookup n numberWords
+  where
+    numberWords = case lang of
+      English -> English.numberWords
+      German  -> German.numberWords
 
 trailingCommaGerman :: String -> String
 trailingCommaGerman = German.trailingComma

--- a/src/Modelling/CdOd/Phrasing/English.hs
+++ b/src/Modelling/CdOd/Phrasing/English.hs
@@ -5,6 +5,7 @@
 module Modelling.CdOd.Phrasing.English (
   phraseChange,
   phraseRelationship,
+  numberWords,
   ) where
 
 import Modelling.Types (
@@ -29,6 +30,12 @@ import Modelling.CdOd.Types (
 import Control.OutputCapable.Blocks     (ArticleToUse (..))
 import Data.String.Interpolate          (iii)
 import Data.Tuple.Extra                 (curry3)
+
+import Data.Map                         (Map)
+import qualified Data.Map          as M (fromList)
+
+numberWords :: Map Int String
+numberWords = M.fromList [(2,"two"),(3,"three"),(4,"four"),(5,"five"),(6,"six"),(7,"seven"),(8,"eight"),(9,"nine"),(10,"ten")]
 
 phraseChange
   :: OmittedDefaultMultiplicities

--- a/src/Modelling/CdOd/Phrasing/English.hs
+++ b/src/Modelling/CdOd/Phrasing/English.hs
@@ -35,7 +35,17 @@ import Data.Map                         (Map)
 import qualified Data.Map          as M (fromList)
 
 numberWords :: Map Int String
-numberWords = M.fromList [(2,"two"),(3,"three"),(4,"four"),(5,"five"),(6,"six"),(7,"seven"),(8,"eight"),(9,"nine"),(10,"ten")]
+numberWords = M.fromList [
+  (2, "two"),
+  (3, "three"),
+  (4, "four"),
+  (5, "five"),
+  (6, "six"),
+  (7, "seven"),
+  (8, "eight"),
+  (9, "nine"),
+  (10, "ten")
+  ]
 
 phraseChange
   :: OmittedDefaultMultiplicities

--- a/src/Modelling/CdOd/Phrasing/German.hs
+++ b/src/Modelling/CdOd/Phrasing/German.hs
@@ -36,7 +36,17 @@ import Data.Map                         (Map)
 import qualified Data.Map          as M (fromList)
 
 numberWords :: Map Int String
-numberWords = M.fromList [(2,"zwei"),(3,"drei"),(4,"vier"),(5,"fünf"),(6,"sechs"),(7,"sieben"),(8,"acht"),(9,"neun"),(10,"zehn")]
+numberWords = M.fromList [
+  (2, "zwei"),
+  (3, "drei"),
+  (4, "vier"),
+  (5, "fünf"),
+  (6, "sechs"),
+  (7, "sieben"),
+  (8, "acht"),
+  (9, "neun"),
+  (10, "zehn")
+  ]
 
 phraseChange
   :: OmittedDefaultMultiplicities

--- a/src/Modelling/CdOd/Phrasing/German.hs
+++ b/src/Modelling/CdOd/Phrasing/German.hs
@@ -6,6 +6,7 @@ module Modelling.CdOd.Phrasing.German (
   phraseChange,
   phraseRelationship,
   trailingComma,
+  numberWords,
   ) where
 
 import Modelling.Types (
@@ -30,6 +31,12 @@ import Modelling.CdOd.Types (
 import Control.OutputCapable.Blocks     (ArticleToUse (..))
 import Data.String.Interpolate          (iii)
 import Data.Tuple.Extra                 (curry3)
+
+import Data.Map                         (Map)
+import qualified Data.Map          as M (fromList)
+
+numberWords :: Map Int String
+numberWords = M.fromList [(2,"zwei"),(3,"drei"),(4,"vier"),(5,"fünf"),(6,"sechs"),(7,"sieben"),(8,"acht"),(9,"neun"),(10,"zehn")]
 
 phraseChange
   :: OmittedDefaultMultiplicities


### PR DESCRIPTION
_Closes #550._

This would be a suggestion without introducing an new external package. It includes the number words up to _ten_, so if, in the future, there is any necessity for higher number words, we would need to add them manually to the list.

Regarding the wording "neither, either, or both class diagrams", I think replacing it with "none, one, or multiple" should be okay.

I've also looked into whether there are any other tasks that would profit from variable number words but wasn't able to find any.