### PR TITLE
Fix layout agreement issues on diagram reprinting

### DIFF
--- a/src/Modelling/CdOd/Output.hs
+++ b/src/Modelling/CdOd/Output.hs
@@ -150,7 +150,7 @@ relationshipArrow CdDrawSettings {..} marking isThick =
             $ limits compositionPart
           ]
         ++ concat [maybeToList marking | isThick]
-        ++ [toLabel compositionName | printNames]
+        ++ [toLabel compositionName]
       Aggregation {..} -> [
           arrowFrom oDiamond,
           edgeEnds Back,
@@ -162,7 +162,7 @@ relationshipArrow CdDrawSettings {..} marking isThick =
             $ limits aggregationPart
           ]
         ++ concat [maybeToList marking | isThick]
-        ++ [toLabel aggregationName | printNames]
+        ++ [toLabel aggregationName]
       Association {..} -> associationArrow ++ [
           TailLabel $ multiplicity
             (associationOmittedDefaultMultiplicity omittedDefaults)
@@ -172,7 +172,7 @@ relationshipArrow CdDrawSettings {..} marking isThick =
             $ limits associationTo
           ]
         ++ concat [maybeToList marking | isThick]
-        ++ [toLabel associationName | printNames]
+        ++ [toLabel associationName]
     associationArrow
       | printNavigations = [arrowTo vee, ArrowSize 0.4]
       | otherwise        = [ArrowHead noArrow]


### PR DESCRIPTION
Closes #463 

It turned out that only these changes are necessary to have the same diagram layout (found that out while implementing the approach mentioned in https://github.com/fmidue/modelling-tasks/issues/463#issuecomment-3607105568). 

Before 
-----
(used diagram is `fromClassDiagram $ (Map.! 1) $ diagrams defaultMatchCdOdInstance`)
![before_with_names](https://github.com/user-attachments/assets/7132d7c9-0631-4efa-87a6-763f4ee2b09e)
![before_without_names](https://github.com/user-attachments/assets/ac1daa10-28da-4a46-bd48-371fb2077bde)

After
-----
![after_with_names](https://github.com/user-attachments/assets/3266f7ba-85c5-4759-a4d3-452a14871404)
![after_without_names](https://github.com/user-attachments/assets/552fffb5-5df8-4b1f-acfb-b291a940b5ae)

My guess is that this not only applies to this example.