### PR TITLE
export defaultMatchCdOdTaskText

### DIFF
--- a/src/Modelling/CdOd/MatchCdOd.hs
+++ b/src/Modelling/CdOd/MatchCdOd.hs
@@ -17,6 +17,7 @@ module Modelling.CdOd.MatchCdOd (
   checkMatchCdOdInstance,
   defaultMatchCdOdConfig,
   defaultMatchCdOdInstance,
+  defaultMatchCdOdTaskText,
   getMatchCdOdTask,
   getODInstances,
   matchCdOd,


### PR DESCRIPTION
`defaultMatchCdOdTaskText` can be reused when creating the `MatchCdOd` variant with only one CD ([https://github.com/fmidue/llm-task-wrappers/issues/153](https://github.com/fmidue/llm-task-wrappers/issues/153)).