### PR TITLE
exclude some taskText elements in checkNameCdErrorInstance

### DIFF
--- a/example/test/ExamplesSpec.hs
+++ b/example/test/ExamplesSpec.hs
@@ -376,7 +376,7 @@ spec =
       it "task13" $
         checkRepairCdConfig task2024_13 `shouldBe` Nothing
       it "task14" $
-        checkNameCdErrorInstance (All.taskInstance task2024_14)
+        checkNameCdErrorInstance True (All.taskInstance task2024_14)
         `shouldBe` Nothing
       it "task15" $
         checkDifferentNamesConfig task2024_15 `shouldBe` Nothing
@@ -512,7 +512,7 @@ spec =
       it "task11" $
         checkRepairCdConfig task2025_11 `shouldBe` Nothing
       it "task12" $
-        checkNameCdErrorInstance (All.taskInstance task2025_12)
+        checkNameCdErrorInstance True (All.taskInstance task2025_12)
         `shouldBe` Nothing
       it "task13" $
         checkDifferentNamesConfig task2025_13 `shouldBe` Nothing

--- a/src/Modelling/Auxiliary/Output.hs
+++ b/src/Modelling/Auxiliary/Output.hs
@@ -7,6 +7,7 @@
 module Modelling.Auxiliary.Output (
   addPretext,
   checkTaskText,
+  checkTaskTextExcluding,
   directionsAdvice,
   hoveringInformation,
   simplifiedInformation,
@@ -31,7 +32,7 @@ import Control.OutputCapable.Blocks.Type (
   SpecialOutput,
   checkTranslations,
   )
-import Data.List                        ((\\), singleton)
+import Data.List                        ((\\), singleton, intersect)
 import Data.Map                         (Map)
 import Data.String.Interpolate          (iii)
 
@@ -107,9 +108,18 @@ checkTaskText
   :: (Bounded element, Enum element, Eq element, Show element)
   => [SpecialOutput element]
   -> Maybe String
-checkTaskText taskText
-  | x:_ <- allElements \\ usedElements
+checkTaskText = checkTaskTextExcluding []
+
+checkTaskTextExcluding
+  :: (Bounded element, Enum element, Eq element, Show element)
+  => [element]
+  -> [SpecialOutput element]
+  -> Maybe String
+checkTaskTextExcluding excludes taskText
+  | x:_ <- (allElements \\ usedElements) \\ excludes
   = Just [iii|Your task text is incomplete as it is missing '#{show x}'.|]
+  | x:_ <- excludes `intersect` usedElements
+  = Just [iii|Your task text uses '#{show x}', but it is not allowed.|]
   | x:_ <- usedElements \\ allElements
   = Just [iii|
       Your task text is using '#{show x}' at least twice,

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -75,7 +75,7 @@ import Modelling.Auxiliary.Common (
   )
 import Modelling.Auxiliary.Output (
   addPretext,
-  checkTaskText,
+  checkTaskTextExcluding,
   hoveringInformation,
   simplifiedInformation,
   uniform,
@@ -482,8 +482,8 @@ isRelevant =
   (\case NotRelevant -> False; Relevant {} -> True)
   . annotation
 
-checkNameCdErrorInstance :: NameCdErrorInstance -> Maybe String
-checkNameCdErrorInstance NameCdErrorInstance {..}
+checkNameCdErrorInstance :: Bool -> NameCdErrorInstance -> Maybe String
+checkNameCdErrorInstance withRelationshipChoices NameCdErrorInstance {..}
   | not (printNames cdDrawSettings) && byName
   = Just "by name is only possible when printing names"
   | 1 /= length (filter fst $ M.elems errorReasons)
@@ -508,9 +508,11 @@ checkNameCdErrorInstance NameCdErrorInstance {..}
   | x:_ <- concatMap (checkTranslation . translateReason True) reasons
   = Just $ [i|Problem within 'errorReasons': |] ++ x
   | otherwise
-  = checkTaskText taskText
+  = checkTaskTextExcluding taskTextExcludes taskText
   <|> checkCdDrawSettings cdDrawSettings
   where
+    taskTextExcludes =
+      if withRelationshipChoices then [] else [RelationshipsList]
     letters = ['a' .. 'z'] ++ ['A' .. 'Z']
     reasons = map snd $ M.elems errorReasons
     listingPriorities = map (listingPriority . annotation)

--- a/src/Modelling/CdOd/NameCdError.hs
+++ b/src/Modelling/CdOd/NameCdError.hs
@@ -511,8 +511,7 @@ checkNameCdErrorInstance withRelationshipChoices NameCdErrorInstance {..}
   = checkTaskTextExcluding taskTextExcludes taskText
   <|> checkCdDrawSettings cdDrawSettings
   where
-    taskTextExcludes =
-      if withRelationshipChoices then [] else [RelationshipsList]
+    taskTextExcludes = [RelationshipsList | not withRelationshipChoices]
     letters = ['a' .. 'z'] ++ ['A' .. 'Z']
     reasons = map snd $ M.elems errorReasons
     listingPriorities = map (listingPriority . annotation)

--- a/test/Modelling/CdOd/NameCdErrorSpec.hs
+++ b/test/Modelling/CdOd/NameCdErrorSpec.hs
@@ -30,7 +30,7 @@ spec = do
       checkNameCdErrorConfig defaultNameCdErrorConfig `shouldBe` Nothing
   describe "defaultNameCdErrorInstance" $
     it "is valid" $
-      checkNameCdErrorInstance defaultNameCdErrorInstance `shouldBe` Nothing
+      checkNameCdErrorInstance True defaultNameCdErrorInstance `shouldBe` Nothing
   describe "nameCdErrorGenerate" $
     context "using defaultNameCdErrorConfig" $ do
       it "generates an instance" $


### PR DESCRIPTION
following #630, the taskText in `NameCdErrorInstance` does not always use all elements of `NameCdErrorTaskElement`

related: https://git.uni-due.de/fmi/autotool-dev/-/merge_requests/83#note_253139